### PR TITLE
Add Claude Usage SwiftBar plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,158 @@
+# Claude Usage Menu Bar Widget
+
+Claude.ai の使用量（セッション / 全モデル / Sonnet）を Mac のメニューバーにリアルタイム表示する SwiftBar プラグイン。
+
+## 表示内容
+
+```
+🟡 Session:18%  All:41%  Sonnet:28%
+```
+
+クリックで展開：
+
+```
+🟡 現在のセッション: 18%
+   ██░░░░░░░░░░ 18%
+   📈 5h予測: 83%
+   🔄 3時間57分後にリセット
+---
+🟢 すべてのモデル: 41%
+   █████░░░░░░░ 41%
+   📈 7d予測: 49%
+   🔄 水 20:59 にリセット
+---
+🟢 Sonnet のみ: 28%
+   ███░░░░░░░░░ 28%
+   📈 7d予測: 31%
+   🔄 14時間57分後にリセット
+---
+↗ claude.ai/settings/usage
+↺ 今すぐ更新
+```
+
+### アイコンの意味
+
+| アイコン | 条件 |
+|--------|------|
+| 🟢 | ウィンドウ終了時の予測使用率 < 80% |
+| 🟡 | ウィンドウ終了時の予測使用率 ≥ 80% |
+| 🔴 | ウィンドウ終了時の予測使用率 ≥ 100%（オーバー） |
+
+メニューバー左端のアイコンは、全指標のうち**最も悪い予測**を表示します。
+
+## セットアップ
+
+### 1. SwiftBar をインストール
+
+```bash
+brew install --cask swiftbar
+```
+
+または [swiftbar.app](https://swiftbar.app) からダウンロード。
+
+### 2. 依存ライブラリをインストール
+
+```bash
+pip3 install browser-cookie3 requests
+```
+
+> **重要**: SwiftBar は独自の環境でスクリプトを実行するため、shebang に Python の絶対パスを指定する必要があります。
+
+どの python3 を使っているか確認：
+
+```bash
+which python3
+```
+
+`claude-usage.5m.py` の1行目を実際のパスに書き換えます：
+
+```python
+#!/usr/bin/env python3   # デフォルト（PATHが通っている場合）
+# または
+#!/Users/yourname/.local/share/mise/installs/python/3.14.3/bin/python3  # mise 使用時
+# または
+#!/opt/homebrew/bin/python3  # Homebrew で直接インストール時
+```
+
+mise を使っている場合は以下で確認できます：
+
+```bash
+mise which python3
+```
+
+### 3. プラグインフォルダを作成してスクリプトを配置
+
+```bash
+# プラグインフォルダを作成（場所は自由）
+mkdir -p ~/Documents/SwiftBar
+
+# スクリプトをコピー
+cp claude-usage.5m.py ~/Documents/SwiftBar/
+
+# 実行権限を付与
+chmod +x ~/Documents/SwiftBar/claude-usage.5m.py
+```
+
+### 4. SwiftBar を起動してフォルダを選択
+
+1. SwiftBar を起動
+2. プラグインフォルダの選択ダイアログが表示されたら `~/Documents/SwiftBar` を選択
+3. メニューバーに Claude の使用量が表示されれば完了
+
+### 5. 動作確認
+
+SwiftBar アイコン → **Refresh All** で更新。
+
+表示されない場合はターミナルで直接実行して確認：
+
+```bash
+# SwiftBar と同じ環境変数をセットして実行
+export SWIFTBAR=1
+python3 ~/Documents/SwiftBar/claude-usage.5m.py
+```
+
+## トラブルシューティング
+
+### `依存ライブラリ不足: browser_cookie3`
+
+SwiftBar が別の Python を使っています。shebang を `browser_cookie3` がインストールされている Python の絶対パスに変更してください。
+
+```bash
+# browser_cookie3 がある Python を探す
+python3 -c "import browser_cookie3; import sys; print(sys.executable)"
+```
+
+出力されたパスを shebang に設定します。
+
+### `エラー: Keychain access failed` などの認証エラー
+
+Chrome で claude.ai にログインしているか確認してください。ブラウザで一度 `claude.ai/settings/usage` を開いてから再試行してください。
+
+### ネット切断時
+
+- 📵 Claude（グレー）→ オフライン
+- ⏳ Claude（グレー）→ タイムアウト（再試行ボタンあり）
+
+## 更新頻度のカスタマイズ
+
+ファイル名の `5m` が更新間隔です。変更する場合はファイルをリネームします：
+
+```bash
+# 1分ごとに更新
+mv ~/Documents/SwiftBar/claude-usage.5m.py ~/Documents/SwiftBar/claude-usage.1m.py
+
+# 10分ごとに更新
+mv ~/Documents/SwiftBar/claude-usage.5m.py ~/Documents/SwiftBar/claude-usage.10m.py
+```
+
+## 仕組み
+
+Chrome の Cookie を使って `claude.ai/api/organizations/{uuid}/usage` という JSON エンドポイントを直接叩いています。HTML スクレイピングではないため、UI が変わっても動作します。
+
+取得するデータ：
+
+| キー | 意味 | ウィンドウ |
+|-----|------|---------|
+| `five_hour` | 現在のセッション使用量 | 5時間 |
+| `seven_day` | 全モデルの使用量 | 7日間 |
+| `seven_day_sonnet` | Sonnet のみの使用量 | 7日間 |

--- a/claude-usage.5m.py
+++ b/claude-usage.5m.py
@@ -1,0 +1,221 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# <xbar.title>Claude Usage</xbar.title>
+# <xbar.version>v1.1</xbar.version>
+# <xbar.author>kmatsunami</xbar.author>
+# <xbar.desc>Claude.ai の使用量（セッション / 全モデル / Sonnet）をメニューバーに表示</xbar.desc>
+# <xbar.dependencies>python3,browser-cookie3,requests</xbar.dependencies>
+#
+# <swiftbar.hideAbout>true</swiftbar.hideAbout>
+# <swiftbar.hideRunInTerminal>false</swiftbar.hideRunInTerminal>
+# <swiftbar.hideLastUpdated>false</swiftbar.hideLastUpdated>
+# <swiftbar.hideDisablePlugin>false</swiftbar.hideDisablePlugin>
+# <swiftbar.hideSwiftBar>false</swiftbar.hideSwiftBar>
+#
+# セットアップ:
+#   pip3 install browser-cookie3 requests
+#   このファイルを SwiftBar のプラグインフォルダにコピーして chmod +x
+
+import sys
+from datetime import datetime, timezone
+
+try:
+    import browser_cookie3
+    import requests
+except ImportError as e:
+    missing = str(e).replace("No module named ", "").strip("'")
+    print("⚠️ Claude Usage")
+    print("---")
+    print(f"依存ライブラリ不足: {missing}")
+    print("ターミナルで実行してください | size=11 color=gray")
+    print("pip3 install browser-cookie3 requests | bash=/bin/sh "
+          "param1=-c param2='pip3 install browser-cookie3 requests' terminal=true")
+    sys.exit(0)
+
+BASE_URL = "https://claude.ai"
+
+# 画面表示の設定  (key, label_en, label_jp, window_hours)
+METRICS = [
+    ("five_hour",       "Session", "現在のセッション",   5),
+    ("seven_day",       "All",     "すべてのモデル",    168),
+    ("seven_day_sonnet","Sonnet",  "Sonnet のみ",      168),
+]
+
+# ── Cookie 取得 ─────────────────────────────────────────────
+def get_session(cookie_jar):
+    s = requests.Session()
+    headers = {
+        "User-Agent": (
+            "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
+            "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/145.0.0.0 Safari/537.36"
+        ),
+        "Accept": "application/json",
+        "Content-Type": "application/json",
+        "Referer": "https://claude.ai/settings/usage",
+    }
+    s.headers.update(headers)
+    for c in cookie_jar:
+        s.cookies.set(c.name, c.value, domain=c.domain)
+    return s
+
+# ── API 呼び出し ────────────────────────────────────────────
+def get_org_uuid(session):
+    r = session.get(f"{BASE_URL}/api/organizations", timeout=10)
+    r.raise_for_status()
+    orgs = r.json()
+    if not orgs:
+        raise RuntimeError("組織が見つかりません")
+    return orgs[0]["uuid"]
+
+def get_usage(session, org_uuid):
+    r = session.get(f"{BASE_URL}/api/organizations/{org_uuid}/usage", timeout=10)
+    r.raise_for_status()
+    return r.json()
+
+# ── 表示ヘルパー ─────────────────────────────────────────────
+def pct_color(pct):
+    if pct >= 85: return "red"
+    if pct >= 60: return "orange"
+    return "green"
+
+def progress_bar(pct, width=12):
+    filled = round(pct / 100 * width)
+    return "█" * filled + "░" * (width - filled)
+
+def calc_projected(pct, resets_at_str, window_hours):
+    """現在のペースでウィンドウ終了時に到達する予測使用率を返す。
+    計算不能な場合は None。"""
+    if not resets_at_str or pct <= 0:
+        return None
+    try:
+        resets_at = datetime.fromisoformat(resets_at_str)
+        now = datetime.now(timezone.utc)
+        time_remaining_h = (resets_at - now).total_seconds() / 3600
+        time_elapsed_h = window_hours - time_remaining_h
+        if time_elapsed_h < 0.05:   # 開始直後は計算しない（ゼロ除算防止）
+            return None
+        burn_rate = pct / time_elapsed_h        # %/hour
+        return burn_rate * window_hours          # ウィンドウ終了時の予測値
+    except Exception:
+        return None
+
+def burn_icon(projected):
+    """burn rate 予測値からアイコン絵文字を返す。"""
+    if projected is None:   return "🟢"
+    if projected >= 100:    return "🔴"
+    if projected >= 80:     return "🟡"
+    return "🟢"
+
+def status_icon(projected):
+    """メニューバー左端アイコン（セッションの burn rate 基準）。"""
+    return burn_icon(projected)
+
+def format_reset(resets_at_str):
+    """resets_at → '3時間12分後' または '水 21:00' 形式"""
+    if not resets_at_str:
+        return ""
+    try:
+        resets_at = datetime.fromisoformat(resets_at_str)
+        now = datetime.now(timezone.utc)
+        delta = resets_at - now
+        total_seconds = int(delta.total_seconds())
+        if total_seconds <= 0:
+            return "まもなくリセット"
+        hours = total_seconds // 3600
+        minutes = (total_seconds % 3600) // 60
+        if hours >= 24:
+            day_names = ["月", "火", "水", "木", "金", "土", "日"]
+            local = resets_at.astimezone()
+            return f"{day_names[local.weekday()]} {local.strftime('%H:%M')} にリセット"
+        if hours > 0:
+            return f"{hours}時間{minutes}分後にリセット"
+        return f"{minutes}分後にリセット"
+    except Exception:
+        return ""
+
+# ── メイン ───────────────────────────────────────────────────
+def main():
+    try:
+        cookie_jar = browser_cookie3.chrome(domain_name=".claude.ai")
+        session = get_session(cookie_jar)
+        org_uuid = get_org_uuid(session)
+        usage = get_usage(session, org_uuid)
+    except requests.exceptions.ConnectionError:
+        print("📵 Claude  |  color=gray")
+        print("---")
+        print("オフライン  |  color=gray")
+        return
+    except requests.exceptions.Timeout:
+        print("⏳ Claude  |  color=gray")
+        print("---")
+        print("タイムアウト  |  color=gray")
+        print("↺ 再試行  |  refresh=true")
+        return
+    except Exception as e:
+        print("⚠️ Claude Usage")
+        print("---")
+        print(f"エラー: {str(e)[:120]}")
+        print("---")
+        print("設定ページを開く | href=https://claude.ai/settings/usage")
+        return
+
+    # 有効な指標だけ抽出し、各自の burn rate 予測も計算
+    items = []
+    for key, label_en, label_jp, window_hours in METRICS:
+        data = usage.get(key)
+        if data is None:
+            continue
+        pct = int(data.get("utilization", 0))
+        resets_at = data.get("resets_at")
+        proj = calc_projected(pct, resets_at, window_hours)
+        items.append({
+            "key": key,
+            "label_en": label_en,
+            "label_jp": label_jp,
+            "window_hours": window_hours,
+            "pct": pct,
+            "projected": proj,
+            "reset": format_reset(resets_at),
+        })
+
+    if not items:
+        print("⚠️ Claude Usage")
+        print("---")
+        print("データなし（ログインが必要かもしれません）")
+        print("設定ページを開く | href=https://claude.ai/settings/usage")
+        return
+
+    # メニューバーアイコンは全指標のうち最も悪い予測で決める
+    worst_projected = max(
+        (i["projected"] for i in items if i["projected"] is not None),
+        default=None
+    )
+
+    # ── メニューバー タイトル ──────────────────────────────────
+    bar_title = "  ".join(f"{i['label_en']}:{i['pct']}%" for i in items)
+    print(f"{status_icon(worst_projected)} {bar_title}")
+
+    # ── ドロップダウン ────────────────────────────────────────
+    print("---")
+    for item in items:
+        proj = item["projected"]
+        icon = burn_icon(proj)
+        c = pct_color(item["pct"])
+        bar = progress_bar(item["pct"])
+        window_label = f"{item['window_hours']}h" if item["window_hours"] < 24 else f"{item['window_hours']//24}d"
+        print(f"{icon} {item['label_jp']}: {item['pct']}%  |  color={c}")
+        print(f"   {bar} {item['pct']}%  |  font=Menlo size=12 color={c}")
+        if proj is not None:
+            proj_color = "red" if proj >= 100 else "orange" if proj >= 80 else "gray"
+            print(f"   📈 {window_label}予測: {proj:.0f}%  |  size=11 color={proj_color}")
+        if item["reset"]:
+            print(f"   🔄 {item['reset']}  |  size=11 color=gray")
+        print("---")
+
+    print("↗ claude.ai/settings/usage  |  href=https://claude.ai/settings/usage")
+    print("↺ 今すぐ更新  |  refresh=true")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Adds `claude-usage.5m.py`: SwiftBar plugin that displays Claude.ai usage (Session / All models / Sonnet) in the Mac menu bar
- Adds `README.md`: step-by-step setup guide for Mac

## Features

- Fetches usage data from `claude.ai/api/organizations/{uuid}/usage` using Chrome cookies (no scraping)
- Burn rate prediction per metric with color-coded icons (🟢/🟡/🔴)
- Menu bar icon reflects the worst predicted metric across all three
- Offline/timeout handling with graceful fallback display
- Refreshes every 5 minutes (configurable via filename)

## Test plan

- [ ] `pip3 install browser-cookie3 requests`
- [ ] Set shebang to correct Python path
- [ ] Copy to SwiftBar plugins folder and `chmod +x`
- [ ] Verify menu bar shows usage percentages
- [ ] Verify dropdown shows per-metric burn rate predictions

🤖 Generated with [Claude Code](https://claude.com/claude-code)