### PR TITLE
Show current→projected % always; remove redundant % from label line

### DIFF
--- a/src/claude-usage.5m.py
+++ b/src/claude-usage.5m.py
@@ -334,8 +334,8 @@ def main():
             if item["window_hours"] < 24
             else f"{item['window_hours']//24}d"
         )
-        print(f"{icon} {item['label_jp']}: {item['pct']}%  |  color={c}")
-        bar_label = f"{item['pct']}% → {proj:.0f}%" if proj and proj > 100 else f"{item['pct']}%"
+        print(f"{icon} {item['label_jp']}  |  color={c}")
+        bar_label = f"{item['pct']}% → {proj:.0f}%" if proj is not None else f"{item['pct']}%"
         print(f"   {bar} {bar_label}  |  font=Menlo size=12 color={c}")
         if proj is not None:
             proj_color = (


### PR DESCRIPTION
## Summary

- バーのラベルを **常時 `X% → Y%` 表示** に変更（従来は予測が100%超の時のみ表示）
- ドロップダウンのラベル行（現在のセッション / すべてのモデル等）から **冗長な `%` 表示を廃止**

## Changes

```diff
- print(f"{icon} {item['label_jp']}: {item['pct']}%  |  color={c}")
- bar_label = f"{item['pct']}% → {proj:.0f}%" if proj and proj > 100 else f"{item['pct']}%"
+ print(f"{icon} {item['label_jp']}  |  color={c}")
+ bar_label = f"{item['pct']}% → {proj:.0f}%" if proj is not None else f"{item['pct']}%"
```

## Before / After

| | Before | After |
|---|---|---|
| ラベル行 | `🟢 現在のセッション: 42%` | `🟢 現在のセッション` |
| バーラベル | `████░░░░░░░░ 42%`（100%未満の場合） | `████░░░░░░░░ 42% → 87%`（proj あれば常時） |

🤖 Generated with [Claude Code](https://claude.com/claude-code)