### PR TITLE
WIP: preserve codex widget migration changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .claude/
+.worktrees/
 __pycache__/
 *.pyc

--- a/README.md
+++ b/README.md
@@ -1,33 +1,28 @@
-# Claude Usage Menu Bar Widget
+# Codex Usage Menu Bar Widget
 
-Claude.ai の使用量（セッション / 全モデル / Sonnet）を Mac のメニューバーにリアルタイム表示する SwiftBar プラグイン。
+Codex の使用量を Mac のメニューバーにリアルタイム表示する SwiftBar プラグイン。
 探して見つからなかったので自作したが、 https://github.com/steipete/CodexBar というOSSがすでにあった。
 
 ## 表示内容
 
 ```
-🟡 Session:18%  All:41%  Sonnet:28%
+🟡 5h:18%  🟢 Weekly:41%
 ```
 
 クリックで展開：
 
 ```
-🟡 現在のセッション: 18%
+🟡 5h usage: 18%
    ██░░░░░░░░░░ 18%
    📈 5h予測: 83%
    🔄 3時間57分後にリセット
 ---
-🟢 すべてのモデル: 41%
+🟢 Weekly usage: 41%
    █████░░░░░░░ 41%
    📈 7d予測: 49%
    🔄 水 20:59 にリセット
 ---
-🟢 Sonnet のみ: 28%
-   ███░░░░░░░░░ 28%
-   📈 7d予測: 31%
-   🔄 14時間57分後にリセット
----
-↗ claude.ai/settings/usage
+↗ chatgpt.com/codex/settings/usage
 ↺ 今すぐ更新
 ```
 
@@ -57,25 +52,25 @@ brew install --cask swiftbar
 
 | 方式 | 設定値 | 依存 | 認証 |
 |------|--------|------|------|
-| **browser** | `"browser"` | `browser-cookie3` + `requests` | Chrome の Cookie（claude.ai ログイン済み） |
-| **oauth** | `"oauth"` | `requests` のみ | macOS Keychain の Claude Code OAuth トークン |
+| **browser** | `"browser"` | `browser-cookie3` + `requests` | Chrome/Safari/Firefox の Cookie（OpenAI ダッシュボード） |
+| **oauth** | `"oauth"` | `requests` のみ | `~/.codex/auth.json` の OAuth トークン |
 
-**oauth モード**（デフォルト）: Claude Code にログイン済みであれば追加設定不要。`browser-cookie3` も不要。
+**oauth モード**（デフォルト）: Codex にログイン済みで `~/.codex/auth.json` があれば追加設定不要。`browser-cookie3` も不要。
 
 ```bash
 pip3 install requests
 ```
 
-**browser モード**: Chrome で claude.ai にログインしている環境向け。
+**browser モード**: OpenAI ダッシュボードの Cookie から usage ページを読む代替手段です。`auth.json` がない場合の保険として使ってください。
 
 ```bash
 pip3 install browser-cookie3 requests
 ```
 
-`~/.claude-usage-config.json` で方式を切り替えられます：
+`~/.codex-usage-config.json` で方式を切り替えられます：
 
 ```json
-{"data_source": "browser"}
+{"data_source": "oauth"}
 ```
 
 > **重要**: SwiftBar は独自の環境でスクリプトを実行するため、shebang に Python の絶対パスを指定する必要があります。
@@ -114,15 +109,17 @@ cp src/claude-usage.5m.py ~/Documents/SwiftBar/
 # 実行権限を付与
 chmod +x ~/Documents/SwiftBar/claude-usage.5m.py
 
-# 設定ファイルをコピー（お好みで編集）
-cp config.example.json ~/.claude-usage-config.json
+# 設定ファイルを作成（お好みで編集）
+cat > ~/.codex-usage-config.json <<'JSON'
+{"data_source":"oauth"}
+JSON
 ```
 
 ### 4. SwiftBar を起動してフォルダを選択
 
 1. SwiftBar を起動
 2. プラグインフォルダの選択ダイアログが表示されたら `~/Documents/SwiftBar` を選択
-3. メニューバーに Claude の使用量が表示されれば完了
+3. メニューバーに Codex の使用量が表示されれば完了
 
 ### 5. 動作確認
 
@@ -169,18 +166,18 @@ python3 -c "import browser_cookie3; import sys; print(sys.executable)"
 
 ### 認証エラー（401 / 403）
 
-**browser モード**: Chrome で claude.ai にログインしているか確認してください。ブラウザで一度 `claude.ai/settings/usage` を開いてから再試行。
+**browser モード**: OpenAI ダッシュボードにログインしているか確認してください。ブラウザで一度 `https://chatgpt.com/codex/settings/usage` を開いてから再試行。
 
-**oauth モード**: Claude Code のトークンが期限切れです。Claude Code を再ログイン（`/logout` → `claude`）してください。
+**oauth モード**: `~/.codex/auth.json` の access token が期限切れです。Codex に再ログインしてください。
 
 ### ネット切断時
 
-- 📵 Claude（グレー）→ オフライン
-- ⏳ Claude（グレー）→ タイムアウト（再試行ボタンあり）
+- 📵 Codex（グレー）→ オフライン
+- ⏳ Codex（グレー）→ タイムアウト（再試行ボタンあり）
 
 ## カスタマイズ
 
-### 設定ファイル（`~/.claude-usage-config.json`）
+### 設定ファイル（`~/.codex-usage-config.json`）
 
 以下の設定ファイルを作成することで動作をカスタマイズできます。ファイルがない場合はデフォルト値が使われます。
 
@@ -190,7 +187,7 @@ python3 -c "import browser_cookie3; import sys; print(sys.executable)"
   "warn_pct":  80,
   "alert_pct": 100,
   "bar_width": 12,
-  "metrics": ["five_hour", "seven_day", "seven_day_sonnet"]
+  "metrics": ["primary_window", "secondary_window"]
 }
 ```
 
@@ -200,14 +197,14 @@ python3 -c "import browser_cookie3; import sys; print(sys.executable)"
 | `warn_pct` | `80` | 警告通知を送る予測使用率の閾値（🟡） |
 | `alert_pct` | `100` | アラート通知を送る予測使用率の閾値（🔴） |
 | `bar_width` | `12` | プログレスバーの文字数 |
-| `metrics` | 全3指標 | 表示する指標のリスト（順序も反映） |
+| `metrics` | 全指標 | 表示する指標のリスト（順序も反映） |
 
-**設定例**: Sonnet だけ表示、70% 超で警告
+**設定例**: 5h 枠だけ表示、70% 超で警告
 
 ```json
 {
   "warn_pct": 70,
-  "metrics": ["seven_day_sonnet"]
+  "metrics": ["primary_window"]
 }
 ```
 
@@ -217,7 +214,7 @@ python3 -c "import browser_cookie3; import sys; print(sys.executable)"
 
 - 同じリセットサイクル内で各閾値につき **1回のみ** 送信されます（連続通知なし）
 - リセット後は自動的にリセットされます
-- 通知の状態は `~/.claude-usage-alerted.json` で管理されます
+- 通知の状態は `~/.codex-usage-alerted.json` で管理されます
 
 ### 更新頻度のカスタマイズ
 
@@ -243,7 +240,7 @@ python3 -m pytest test_claude_usage.py -v
 | `test_menubar_title_has_percentage` | 1行目に `%` が含まれる（数値表示） |
 | `test_output_has_separator` | SwiftBarフォーマット `---` が含まれる |
 
-> Claude.aiにアクセスできる環境（ログイン済みChrome）が必要です。
+> Codex にアクセスできる環境（`~/.codex/auth.json` または OpenAI ダッシュボード Cookie）が必要です。
 
 ## 仕組み
 
@@ -251,8 +248,8 @@ JSON API を直接叩いて使用量データを取得します（HTML スクレ
 
 | 方式 | エンドポイント |
 |------|--------------|
-| browser | `claude.ai/api/organizations/{uuid}/usage`（Chrome Cookie 認証） |
-| oauth | `api.anthropic.com/api/oauth/usage`（macOS Keychain OAuth トークン認証） |
+| browser | `chatgpt.com/codex/settings/usage`（Cookie から HTML を抽出） |
+| oauth | `chatgpt.com/backend-api/wham/usage`（Codex auth.json の OAuth トークン） |
 
 取得するデータ：
 

--- a/docs/superpowers/plans/2026-03-26-codex-usage.md
+++ b/docs/superpowers/plans/2026-03-26-codex-usage.md
@@ -1,0 +1,128 @@
+# Codex Usage Support Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Update the SwiftBar widget so it can show Codex usage from `https://chatgpt.com/codex/settings/usage` with the same menu-bar workflow and alert behavior.
+
+**Architecture:** Keep the current single-file script structure, but introduce a small provider layer so product-specific values such as base URLs, help links, labels, and fetch logic are centralized. For Codex, fetch the usage page with logged-in ChatGPT session cookies and extract usage data from embedded JSON or other structured page data, so the parsing logic is isolated if the page shape changes.
+
+**Tech Stack:** Python 3.10+, `requests`, `browser_cookie3`, SwiftBar menu-bar plugin format, `pytest`
+
+---
+
+### Task 1: Add Codex provider scaffolding
+
+**Files:**
+- Modify: `src/claude-usage.5m.py`
+- Test: `test_claude_usage.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Add a unit test that imports a new provider helper and asserts the Codex provider exposes the expected product name and usage page URL.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python3 -m pytest test_claude_usage.py -v`
+Expected: fail because the Codex provider helper does not exist yet.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add constants/helpers for product branding, `https://chatgpt.com/codex/settings/usage`, and any product-specific labels used in menu text.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python3 -m pytest test_claude_usage.py -v`
+Expected: pass for the new provider helper test.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/claude-usage.5m.py test_claude_usage.py
+git commit -m "feat: add codex provider scaffolding"
+```
+
+### Task 2: Implement Codex usage fetching
+
+**Files:**
+- Modify: `src/claude-usage.5m.py`
+- Test: `test_claude_usage.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Add tests for a new Codex HTML parser helper using a small fixture string that contains embedded JSON with `utilization` and `resets_at` fields.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python3 -m pytest test_claude_usage.py -v`
+Expected: fail because the parser helper is not implemented yet.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Implement a `fetch_usage_codex()` path that requests the usage page, extracts structured JSON from the HTML when possible, and normalizes it into the same `items` shape used by the renderer.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python3 -m pytest test_claude_usage.py -v`
+Expected: pass for the parser tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/claude-usage.5m.py test_claude_usage.py
+git commit -m "feat: fetch codex usage data"
+```
+
+### Task 3: Rebrand menu output and docs
+
+**Files:**
+- Modify: `src/claude-usage.5m.py`
+- Modify: `README.md`
+- Test: `test_claude_usage.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Add a formatting test that verifies the fallback/error strings and footer link use the Codex usage URL instead of the Claude URL.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python3 -m pytest test_claude_usage.py -v`
+Expected: fail until all user-visible strings are updated.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Update title text, error messages, footer links, and README instructions so the widget reads as a Codex usage widget instead of Claude usage.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python3 -m pytest test_claude_usage.py -v`
+Expected: pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/claude-usage.5m.py README.md test_claude_usage.py
+git commit -m "docs: rebrand widget for codex usage"
+```
+
+### Task 4: Verification
+
+**Files:**
+- Modify: `src/claude-usage.5m.py`
+- Modify: `test_claude_usage.py`
+
+- [ ] **Step 1: Run the full test suite**
+
+Run: `python3 -m pytest -v`
+Expected: all tests pass.
+
+- [ ] **Step 2: Smoke-check the script output**
+
+Run: `bash src/claude-usage.5m.py`
+Expected: a SwiftBar-formatted menu-bar title and dropdown output without syntax errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/claude-usage.5m.py test_claude_usage.py README.md
+git commit -m "test: verify codex usage widget"
+```

--- a/docs/superpowers/plans/2026-03-30-local-history-rate-limit-implementation.md
+++ b/docs/superpowers/plans/2026-03-30-local-history-rate-limit-implementation.md
@@ -1,0 +1,659 @@
+# Local History Rate Limit Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace credential-based Codex and Claude usage fetching with local-history-only parsing, while keeping the existing SwiftBar rendering, cache fallback, and alert workflow intact.
+
+**Architecture:** Keep the current single-file script structure, but formalize a provider layer inside `src/claude-usage.5m.py` that returns structured local-history results. Codex becomes the fully supported local-history provider using JSONL `token_count.rate_limits` snapshots from `~/.codex/sessions` and `~/.codex/archived_sessions`; Claude becomes a strict Phase 1 local provider that only renders percentages when an explicit trustworthy local snapshot exists and otherwise returns an `unavailable` provider result. Legacy `oauth` / `browser` config values are deprecated aliases and no longer enable credential or network fetches.
+
+**Tech Stack:** Python 3.10+ standard library, SwiftBar menu-bar plugin format, `pytest`
+
+---
+
+## File Structure
+
+**Files:**
+- Modify: `src/claude-usage.5m.py`
+  Responsibility: provider result contract, config migration, local-history scanners, cache metadata, main flow, and rendering integration.
+- Modify: `test_claude_usage.py`
+  Responsibility: characterization tests for provider parsing, config migration, cache validation, source-level removal assertions, and main-flow behavior.
+- Modify: `README.md`
+  Responsibility: local-history-only setup and troubleshooting docs.
+- Modify: `config.example.json`
+  Responsibility: show `provider`-based config and deprecate `data_source`.
+- Create: `tests/fixtures/codex-history-primary-secondary.jsonl`
+  Responsibility: newest valid Codex `token_count.rate_limits` snapshot with both windows.
+- Create: `tests/fixtures/codex-history-partial.jsonl`
+  Responsibility: newest valid Codex snapshot with only one usable window.
+- Create: `tests/fixtures/codex-history-invalid.jsonl`
+  Responsibility: malformed/irrelevant lines used to verify fail-safe parsing.
+- Create: `tests/fixtures/codex-history-archived-only.jsonl`
+  Responsibility: valid Codex snapshot used when only `archived_sessions` contains local quota data.
+- Create: `tests/fixtures/claude-history-unavailable.jsonl`
+  Responsibility: readable Claude local history without trustworthy explicit quota percentages, proving Phase 1 fail-closed behavior.
+
+## Data Contracts
+
+Provider result:
+
+```python
+{
+    "status": "ok",  # ok | missing | unreadable | unavailable
+    "reason": "",
+    "snapshot_time": "2026-03-30T12:34:56+00:00" or None,
+    "source_path": "/Users/.../file.jsonl" or None,
+    "cacheable": True,
+    "items": [...],
+}
+```
+
+Cache payload:
+
+```python
+{
+    "cache_schema_version": 2,
+    "cache_source": "local_history",
+    "provider": "codex",
+    "saved_at": "2026-03-30T12:34:56+00:00",
+    "result": {...provider_result...},
+}
+```
+
+Helper signatures:
+
+```python
+def save_cache(provider: str, provider_result: dict) -> None: ...
+def load_cache(provider: str) -> dict | None: ...
+```
+
+Contract rules:
+
+- `load_cache(provider)` returns `provider_result` only, not the raw cache envelope
+- cache reuse is allowed only when `cache_source == "local_history"` and cached `provider` matches the requested provider
+- missing windows are omitted from `items`; there is no placeholder item for an unavailable paired window
+- invalid `provider` values render a local config error in `main()`; they do not silently fall back
+
+### Task 1: Lock the provider contract, config migration, and cache metadata
+
+**Files:**
+- Modify: `src/claude-usage.5m.py`
+- Modify: `test_claude_usage.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add tests for:
+
+- `load_config()` preferring `provider` over deprecated `data_source`
+- deprecated `data_source` values `"oauth"` and `"browser"` normalizing to provider `"codex"`
+- invalid `provider` values producing a local config error path
+- cache readers rejecting entries without both `cache_source == "local_history"` and matching `provider`
+- `main()` rendering a local config error for invalid `provider`
+
+```python
+def test_load_config_prefers_provider_over_legacy_data_source(tmp_path, monkeypatch):
+    module = load_module()
+    config_path = tmp_path / "config.json"
+    config_path.write_text(json.dumps({"provider": "claude", "data_source": "oauth"}))
+    monkeypatch.setattr(module, "CONFIG_PATHS", [config_path])
+    config = module.load_config()
+    assert config["provider"] == "claude"
+
+
+def test_load_config_maps_legacy_data_source_to_codex_provider(tmp_path, monkeypatch):
+    module = load_module()
+    config_path = tmp_path / "config.json"
+    config_path.write_text(json.dumps({"data_source": "browser"}))
+    monkeypatch.setattr(module, "CONFIG_PATHS", [config_path])
+    config = module.load_config()
+    assert config["provider"] == "codex"
+
+
+def test_load_cache_rejects_legacy_cache_provider_mismatch(tmp_path, monkeypatch):
+    module = load_module()
+    cache_path = tmp_path / "cache.json"
+    cache_path.write_text(json.dumps({
+        "cache_schema_version": 2,
+        "cache_source": "local_history",
+        "provider": "claude",
+        "result": {
+            "status": "ok",
+            "reason": "",
+            "snapshot_time": "2026-03-30T12:00:00+00:00",
+            "source_path": "/tmp/claude.jsonl",
+            "cacheable": True,
+            "items": [{"key": "primary_window", "pct": 18}],
+        },
+    }))
+    monkeypatch.setattr(module, "CACHE_PATHS", [cache_path])
+    assert module.load_cache("codex") is None
+
+
+def test_main_renders_invalid_provider_config(monkeypatch):
+    module = load_module()
+    monkeypatch.setattr(module, "load_config", lambda: {
+        "provider": "nope",
+        "caution_pct": 60,
+        "warn_pct": 80,
+        "alert_pct": 100,
+        "bar_width": 12,
+        "metrics": [],
+    })
+    monkeypatch.setattr(module, "load_cache", lambda provider: None)
+    ...
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `python3 -m pytest test_claude_usage.py -k "config or cache" -v`
+Expected: FAIL because the current script does not have `provider` config, provider-scoped cache metadata, or the new invalid-provider rendering behavior.
+
+- [ ] **Step 3: Write the minimal implementation**
+
+Add:
+
+- `DEFAULT_CONFIG["provider"] = "codex"`
+- a config normalizer such as:
+
+```python
+def normalize_provider_config(config):
+    provider = str(config.get("provider", "")).strip().lower()
+    if provider in {"codex", "claude"}:
+        config["provider"] = provider
+        return config
+    legacy = str(config.get("data_source", "")).strip().lower()
+    if legacy in {"oauth", "browser"}:
+        config["provider"] = "codex"
+        return config
+    if provider:
+        raise RuntimeError(f"unsupported provider: {provider}")
+    config["provider"] = "codex"
+    return config
+```
+
+Define a provider-result contract and cache schema:
+
+```python
+{
+    "cache_schema_version": 2,
+    "cache_source": "local_history",
+    "provider": "codex",
+    "saved_at": "2026-03-30T12:34:56+00:00",
+    "result": {...provider_result...},
+}
+```
+
+Update cache helpers so they accept `provider` as an argument and only reuse local-history cache entries for the same provider.
+Handle invalid provider values by rendering a local config error in `main()`, then attempting no provider load at all.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `python3 -m pytest test_claude_usage.py -k "config or cache" -v`
+Expected: PASS for config normalization and provider-scoped cache validation tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/claude-usage.5m.py test_claude_usage.py
+git commit -m "feat: add local history provider config and cache metadata"
+```
+
+### Task 2: Build Codex local-history parsing with a globally newest snapshot rule
+
+**Files:**
+- Create: `tests/fixtures/codex-history-primary-secondary.jsonl`
+- Create: `tests/fixtures/codex-history-partial.jsonl`
+- Create: `tests/fixtures/codex-history-invalid.jsonl`
+- Create: `tests/fixtures/codex-history-archived-only.jsonl`
+- Modify: `src/claude-usage.5m.py`
+- Modify: `test_claude_usage.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add fixture-backed tests for:
+
+- field mapping from local JSON paths to normalized fields
+- timestamp precedence for snapshot selection
+- same-event snapshot consistency
+- partial-window omission behavior
+- malformed-line tolerance
+- `archived_sessions`-only discovery
+- `missing` and `unreadable` status behavior
+
+Use this Codex mapping table as the implementation contract:
+
+- event timestamp: top-level `timestamp`, fallback `payload.timestamp`, fallback file mtime
+- primary window object: `payload.rate_limits.primary`, fallback `payload.rate_limits.primary_window`
+- secondary window object: `payload.rate_limits.secondary`, fallback `payload.rate_limits.secondary_window`
+- percent: `used_percent`, fallback `utilization`, fallback `percentage`, fallback `usage`
+- window length: `window_minutes / 60`, fallback `limit_window_seconds / 3600`
+- reset time: numeric `resets_at` as Unix seconds, fallback string `resets_at`, fallback `reset_at`
+
+```python
+def test_load_codex_history_items_uses_newest_snapshot_from_one_event():
+    module = load_module()
+    result = module.load_codex_history_items([fixture_path("codex-history-primary-secondary.jsonl")])
+    assert result["status"] == "ok"
+    assert [item["key"] for item in result["items"]] == ["primary_window", "secondary_window"]
+    assert result["snapshot_time"] == "2026-03-29T08:44:18.991000+00:00"
+    assert result["items"][0]["pct"] == 4
+    assert result["items"][0]["window_hours"] == 5
+
+
+def test_load_codex_history_items_omits_missing_window_in_partial_snapshot():
+    module = load_module()
+    result = module.load_codex_history_items([fixture_path("codex-history-partial.jsonl")])
+    assert result["status"] == "ok"
+    assert [item["key"] for item in result["items"]] == ["primary_window"]
+
+
+def test_load_codex_history_items_falls_back_to_archived_sessions():
+    module = load_module()
+    result = module.load_codex_history_items(
+        session_paths=[],
+        archived_paths=[fixture_path("codex-history-archived-only.jsonl")],
+    )
+    assert result["status"] == "ok"
+    assert result["source_path"].endswith("codex-history-archived-only.jsonl")
+
+
+def test_load_codex_history_items_returns_missing_when_no_files_exist():
+    module = load_module()
+    result = module.load_codex_history_items(session_paths=[], archived_paths=[])
+    assert result["status"] == "missing"
+
+
+def test_load_codex_history_items_returns_unreadable_on_io_error(monkeypatch):
+    module = load_module()
+    monkeypatch.setattr(module, "iter_jsonl_objects", lambda path: (_ for _ in ()).throw(OSError("boom")))
+    result = module.load_codex_history_items(session_paths=[Path("/tmp/fake.jsonl")], archived_paths=[])
+    assert result["status"] == "unreadable"
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `python3 -m pytest test_claude_usage.py -k "codex_history" -v`
+Expected: FAIL because the current script only knows credential/network Codex loaders and has no Codex JSONL parser.
+
+- [ ] **Step 3: Write the minimal implementation**
+
+Add streaming JSONL helpers:
+
+```python
+def iter_jsonl_objects(path):
+    with path.open() as fh:
+        for raw in fh:
+            raw = raw.strip()
+            if not raw:
+                continue
+            try:
+                yield json.loads(raw)
+            except Exception:
+                continue
+```
+
+Add Codex scanner helpers that:
+
+- expand roots for `~/.codex/sessions/**/*.jsonl` and `~/.codex/archived_sessions/*.jsonl`
+- extract candidate snapshots from `event_msg` + `payload.type == "token_count"`
+- normalize all windows from the same event
+- choose the globally newest candidate by parsed event timestamp
+- return `missing` when no candidate files exist
+- return `unreadable` when filesystem or JSONL iteration errors prevent a trustworthy scan
+- return:
+
+```python
+{
+    "status": "ok",
+    "reason": "",
+    "snapshot_time": "...",
+    "source_path": "...jsonl",
+    "cacheable": True,
+    "items": [...],  # omit missing windows entirely
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `python3 -m pytest test_claude_usage.py -k "codex_history" -v`
+Expected: PASS for Codex fixture parsing, newest-snapshot selection, partial-window omission, archived fallback, and status outcomes.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/claude-usage.5m.py test_claude_usage.py tests/fixtures/codex-history-primary-secondary.jsonl tests/fixtures/codex-history-partial.jsonl tests/fixtures/codex-history-invalid.jsonl
+git commit -m "feat: parse codex rate limits from local history"
+```
+
+### Task 3: Wire provider dispatch, freshness, cache fallback, and local-history error rendering
+
+**Files:**
+- Modify: `src/claude-usage.5m.py`
+- Modify: `test_claude_usage.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add tests that:
+
+- `main()` loads the provider selected by config
+- stale local snapshots suppress notifications
+- local-history cache fallback works only for the active provider
+
+```python
+def test_main_uses_codex_provider_and_renders_local_history(monkeypatch):
+    module = load_module()
+    monkeypatch.setattr(module, "load_config", lambda: {
+        "provider": "codex",
+        "caution_pct": 60,
+        "warn_pct": 80,
+        "alert_pct": 100,
+        "bar_width": 12,
+        "metrics": [],
+    })
+    monkeypatch.setattr(module, "load_usage_items", lambda provider, config: {
+        "status": "ok",
+        "reason": "",
+        "snapshot_time": "2026-03-30T12:00:00+00:00",
+        "source_path": "/tmp/codex.jsonl",
+        "cacheable": True,
+        "items": [{"key": "primary_window", "label_en": "5-hour limit", "label_jp": "現在のセッション", "window_hours": 5, "pct": 18, "resets_at_raw": "2099-03-30T12:00:00+00:00", "projected": None, "reset": "", "exhaust_info": None}],
+    })
+    ...
+
+
+def test_main_uses_provider_scoped_cache_for_missing_local_history(monkeypatch):
+    module = load_module()
+    monkeypatch.setattr(module, "load_config", lambda: {
+        "provider": "codex",
+        "caution_pct": 60,
+        "warn_pct": 80,
+        "alert_pct": 100,
+        "bar_width": 12,
+        "metrics": [],
+    })
+    monkeypatch.setattr(module, "load_usage_items", lambda provider, config: {
+        "status": "missing",
+        "reason": "No Codex history files found.",
+        "snapshot_time": None,
+        "source_path": None,
+        "cacheable": False,
+        "items": [],
+    })
+    monkeypatch.setattr(module, "load_cache", lambda provider: {
+        "status": "ok",
+        "reason": "",
+        "snapshot_time": "2026-03-30T12:00:00+00:00",
+        "source_path": "/tmp/cached.jsonl",
+        "cacheable": True,
+        "items": [{"key": "primary_window", "label_en": "5-hour limit", "label_jp": "現在のセッション", "window_hours": 5, "pct": 18, "resets_at_raw": "2000-03-30T12:00:00+00:00", "projected": None, "reset": "", "exhaust_info": None}],
+    })
+    ...
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `python3 -m pytest test_claude_usage.py -k "main_uses_codex_provider or provider_scoped_cache or invalid_provider" -v`
+Expected: FAIL because `main()` still dispatches `oauth` / `browser` code and does not yet have the new provider-result flow.
+
+- [ ] **Step 3: Write the minimal implementation**
+
+Replace `fetch_usage_oauth()` / `fetch_usage_browser()` dispatch with:
+
+```python
+def load_usage_items(provider, config):
+    if provider == "codex":
+        return load_codex_history_items()
+    if provider == "claude":
+        return load_claude_history_items()
+    raise RuntimeError(f"unsupported provider: {provider}")
+```
+
+Update `main()` to consume provider results:
+
+- `status == "ok"` with future reset timestamps: render and cache
+- `status == "ok"` but stale: render stale without notifications
+- other statuses: try provider-scoped local-history cache, otherwise show local-history-only error
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `python3 -m pytest test_claude_usage.py -k "main_uses_codex_provider or provider_scoped_cache or invalid_provider or cache" -v`
+Expected: PASS for provider dispatch, freshness, provider-scoped cache fallback, and local-history error rendering.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/claude-usage.5m.py test_claude_usage.py
+git commit -m "refactor: switch usage loading to local history providers"
+```
+
+### Task 4: Remove remote fetch code from the wrapper, metadata, and runtime
+
+**Files:**
+- Modify: `src/claude-usage.5m.py`
+- Modify: `test_claude_usage.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add source/runtime tests that assert:
+
+- the polyglot shell wrapper no longer checks for `requests` or `browser_cookie3`
+- SwiftBar dependency metadata no longer advertises third-party packages
+- the module imports with only standard-library dependencies
+- runtime source text no longer references credential/network fetch constants and helpers
+
+```python
+def test_wrapper_no_longer_requires_third_party_packages():
+    text = SCRIPT.read_text()
+    assert "browser_cookie3" not in text
+    assert '"requests"' not in text
+    assert "<xbar.dependencies>python3</xbar.dependencies>" in text
+
+
+def test_source_no_longer_references_auth_or_remote_usage_paths():
+    text = SCRIPT.read_text()
+    assert "auth.json" not in text
+    assert "backend-api/wham/usage" not in text
+    assert "chatgpt.com/codex/settings/usage" not in text
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `python3 -m pytest test_claude_usage.py -k "wrapper_no_longer or source_no_longer_references_auth" -v`
+Expected: FAIL because the current executable header and metadata still mention remote dependencies and runtime source still contains remote-fetch strings.
+
+- [ ] **Step 3: Write the minimal implementation**
+
+Delete or replace:
+
+- bash bootstrap checks for `requests` / `browser_cookie3`
+- `<xbar.dependencies>` references to third-party packages
+- all runtime imports and helpers for cookies, auth, HTTP, remote URLs, and token refresh
+
+Keep only standard-library imports plus local filesystem parsing.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `python3 -m pytest test_claude_usage.py -k "wrapper_no_longer or source_no_longer_references_auth" -v`
+Expected: PASS, proving wrapper, metadata, and runtime code no longer depend on remote-fetch infrastructure.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/claude-usage.5m.py test_claude_usage.py
+git commit -m "refactor: remove remote fetch dependencies"
+```
+
+### Task 5: Add Claude Phase 1 local provider with fail-closed behavior
+
+**Files:**
+- Create: `tests/fixtures/claude-history-unavailable.jsonl`
+- Modify: `src/claude-usage.5m.py`
+- Modify: `test_claude_usage.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add tests for:
+
+- `load_claude_history_items()` returning `status == "unavailable"` when readable local files do not contain an explicit percentage plus an unambiguous reset field that can be normalized to an absolute timestamp
+- `load_claude_history_items()` returning `missing` when no candidate files exist
+- `load_claude_history_items()` returning `unreadable` when candidate files cannot be read
+- `main()` rendering a local-history-only Claude error when provider is `claude` and no provider-scoped cache exists
+
+Concrete Phase 1 contract:
+
+- this plan intentionally uses a stricter rule than the spec wording: accept only rows whose reset field can be normalized to an absolute timestamp at parse time, because freshness and cache eligibility depend on absolute time
+- do not parse free-form transcript summaries
+- do not use `~/.claude/stats-cache.json` for `%`
+
+```python
+def test_load_claude_history_items_returns_unavailable_for_non_quota_history():
+    module = load_module()
+    result = module.load_claude_history_items([fixture_path("claude-history-unavailable.jsonl")])
+    assert result["status"] == "unavailable"
+    assert result["items"] == []
+
+
+def test_load_claude_history_items_returns_missing_when_no_files_exist():
+    module = load_module()
+    result = module.load_claude_history_items([])
+    assert result["status"] == "missing"
+
+
+def test_load_claude_history_items_returns_unreadable_on_io_error(monkeypatch):
+    module = load_module()
+    monkeypatch.setattr(module, "iter_jsonl_objects", lambda path: (_ for _ in ()).throw(OSError("boom")))
+    result = module.load_claude_history_items([Path("/tmp/fake.jsonl")])
+    assert result["status"] == "unreadable"
+
+
+def test_main_renders_claude_local_history_unavailable(monkeypatch):
+    module = load_module()
+    monkeypatch.setattr(module, "load_config", lambda: {
+        "provider": "claude",
+        "caution_pct": 60,
+        "warn_pct": 80,
+        "alert_pct": 100,
+        "bar_width": 12,
+        "metrics": [],
+    })
+    monkeypatch.setattr(module, "load_usage_items", lambda provider, config: {
+        "status": "unavailable",
+        "reason": "Claude local history does not contain explicit quota snapshots.",
+        "snapshot_time": None,
+        "source_path": None,
+        "cacheable": False,
+        "items": [],
+    })
+    ...
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `python3 -m pytest test_claude_usage.py -k "claude_history_items or claude_local_history_unavailable" -v`
+Expected: FAIL because no Claude local-history provider exists yet.
+
+- [ ] **Step 3: Write the minimal implementation**
+
+Implement `load_claude_history_items()` to:
+
+- scan `~/.claude/projects/**/*.jsonl` and `~/.claude/history.jsonl`
+- look only for explicit machine-readable percentage + reset fields that normalize to absolute timestamps
+- return `missing` when no candidate files exist
+- return `unreadable` when filesystem or JSONL iteration errors prevent a trustworthy scan
+- return `unavailable` with no items when none are found
+
+Keep the implementation intentionally conservative:
+
+```python
+return {
+    "status": "unavailable",
+    "reason": "Claude local history does not contain explicit quota snapshots.",
+    "snapshot_time": None,
+    "source_path": None,
+    "cacheable": False,
+    "items": [],
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `python3 -m pytest test_claude_usage.py -k "claude_history_items or claude_local_history_unavailable" -v`
+Expected: PASS for Phase 1 fail-closed Claude behavior.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/claude-usage.5m.py test_claude_usage.py tests/fixtures/claude-history-unavailable.jsonl
+git commit -m "feat: add phase 1 claude local history provider"
+```
+
+### Task 6: Update docs and run final verification
+
+**Files:**
+- Modify: `README.md`
+- Modify: `config.example.json`
+- Modify: `src/claude-usage.5m.py`
+- Modify: `test_claude_usage.py`
+
+- [ ] **Step 1: Write the failing docs/behavior tests**
+
+Add tests that verify:
+
+- `config.example.json` uses `provider`
+- README no longer tells users to log in, install `requests`, or rely on cookies/auth files for quota fetching
+- the wrapper metadata no longer advertises third-party dependencies
+- user-facing error output mentions local history rather than authentication
+
+```python
+def test_readme_documents_local_history_only():
+    text = Path("README.md").read_text()
+    assert '"provider"' in text
+    assert "auth.json" not in text
+    assert "browser-cookie3" not in text
+
+
+def test_config_example_uses_provider_field():
+    config = json.loads(Path("config.example.json").read_text())
+    assert config["provider"] == "codex"
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `python3 -m pytest test_claude_usage.py -k "readme_documents_local_history_only or config_example_uses_provider_field" -v`
+Expected: FAIL because docs and config still describe remote/credentialed fetching.
+
+- [ ] **Step 3: Write the minimal implementation**
+
+Update docs to say:
+
+- quota percentages come from local history only
+- `provider` selects `codex` or `claude`
+- deprecated `data_source` values are accepted only for compatibility
+- first-run empty states are normal when no local history exists yet
+
+Update `config.example.json` to:
+
+```json
+{
+  "provider": "codex",
+  "caution_pct": 60,
+  "warn_pct": 80,
+  "alert_pct": 100,
+  "bar_width": 12,
+  "metrics": []
+}
+```
+
+- [ ] **Step 4: Run the full verification suite**
+
+Run: `python3 -m pytest test_claude_usage.py -v`
+Expected: all tests PASS.
+
+Run: `bash src/claude-usage.5m.py`
+Expected: SwiftBar-formatted output that either shows local-history percentages or a local-history-specific fallback message, with no import/network/auth errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add README.md config.example.json src/claude-usage.5m.py test_claude_usage.py tests/fixtures
+git commit -m "docs: document local history rate limit mode"
+```

--- a/docs/superpowers/plans/2026-03-30-local-history-rate-limit-implementation.md
+++ b/docs/superpowers/plans/2026-03-30-local-history-rate-limit-implementation.md
@@ -139,7 +139,12 @@ def test_main_renders_invalid_provider_config(monkeypatch):
         "metrics": [],
     })
     monkeypatch.setattr(module, "load_cache", lambda provider: None)
-    ...
+    buffer = io.StringIO()
+    with redirect_stdout(buffer):
+        module.main()
+    output = buffer.getvalue()
+    assert "設定エラー" in output
+    assert "provider" in output
 ```
 
 - [ ] **Step 2: Run tests to verify they fail**
@@ -321,6 +326,7 @@ Expected: PASS for Codex fixture parsing, newest-snapshot selection, partial-win
 
 ```bash
 git add src/claude-usage.5m.py test_claude_usage.py tests/fixtures/codex-history-primary-secondary.jsonl tests/fixtures/codex-history-partial.jsonl tests/fixtures/codex-history-invalid.jsonl
+git add tests/fixtures/codex-history-archived-only.jsonl
 git commit -m "feat: parse codex rate limits from local history"
 ```
 
@@ -357,7 +363,17 @@ def test_main_uses_codex_provider_and_renders_local_history(monkeypatch):
         "cacheable": True,
         "items": [{"key": "primary_window", "label_en": "5-hour limit", "label_jp": "現在のセッション", "window_hours": 5, "pct": 18, "resets_at_raw": "2099-03-30T12:00:00+00:00", "projected": None, "reset": "", "exhaust_info": None}],
     })
-    ...
+    saved = {}
+    monkeypatch.setattr(module, "save_cache", lambda provider, result: saved.update({"provider": provider, "status": result["status"]}))
+    monkeypatch.setattr(module, "check_and_notify", lambda items, config: saved.update({"notified": True, "count": len(items)}))
+    buffer = io.StringIO()
+    with redirect_stdout(buffer):
+        module.main()
+    output = buffer.getvalue()
+    assert "18%" in output
+    assert saved["provider"] == "codex"
+    assert saved["status"] == "ok"
+    assert saved["notified"] is True
 
 
 def test_main_uses_provider_scoped_cache_for_missing_local_history(monkeypatch):
@@ -386,7 +402,15 @@ def test_main_uses_provider_scoped_cache_for_missing_local_history(monkeypatch):
         "cacheable": True,
         "items": [{"key": "primary_window", "label_en": "5-hour limit", "label_jp": "現在のセッション", "window_hours": 5, "pct": 18, "resets_at_raw": "2000-03-30T12:00:00+00:00", "projected": None, "reset": "", "exhaust_info": None}],
     })
-    ...
+    called = {"notified": False}
+    monkeypatch.setattr(module, "check_and_notify", lambda items, config: called.update({"notified": True}))
+    buffer = io.StringIO()
+    with redirect_stdout(buffer):
+        module.main()
+    output = buffer.getvalue()
+    assert "前回の値を表示中" in output
+    assert "18%" in output
+    assert called["notified"] is False
 ```
 
 - [ ] **Step 2: Run tests to verify they fail**
@@ -403,15 +427,23 @@ def load_usage_items(provider, config):
     if provider == "codex":
         return load_codex_history_items()
     if provider == "claude":
-        return load_claude_history_items()
+        return {
+            "status": "unavailable",
+            "reason": "Claude local history provider is not wired yet.",
+            "snapshot_time": None,
+            "source_path": None,
+            "cacheable": False,
+            "items": [],
+        }
     raise RuntimeError(f"unsupported provider: {provider}")
 ```
 
 Update `main()` to consume provider results:
 
 - `status == "ok"` with future reset timestamps: render and cache
-- `status == "ok"` but stale: render stale without notifications
+- `status == "ok"` but stale: render stale without notifications, do not overwrite cache, and prefix the menu with `⚠️`
 - other statuses: try provider-scoped local-history cache, otherwise show local-history-only error
+- when no cache exists for a non-`ok` result, render the provider `reason` directly in the dropdown
 
 - [ ] **Step 4: Run tests to verify they pass**
 
@@ -543,7 +575,13 @@ def test_main_renders_claude_local_history_unavailable(monkeypatch):
         "cacheable": False,
         "items": [],
     })
-    ...
+    monkeypatch.setattr(module, "load_cache", lambda provider: None)
+    buffer = io.StringIO()
+    with redirect_stdout(buffer):
+        module.main()
+    output = buffer.getvalue()
+    assert "Claude local history does not contain explicit quota snapshots." in output
+    assert "ローカル履歴" in output
 ```
 
 - [ ] **Step 2: Run tests to verify they fail**
@@ -561,9 +599,17 @@ Implement `load_claude_history_items()` to:
 - return `unreadable` when filesystem or JSONL iteration errors prevent a trustworthy scan
 - return `unavailable` with no items when none are found
 
-Keep the implementation intentionally conservative:
+Keep the implementation intentionally conservative, but with distinct branches:
 
 ```python
+if not candidate_paths:
+    return {"status": "missing", "reason": "Claude local history files were not found.", ...}
+
+try:
+    ...
+except OSError:
+    return {"status": "unreadable", "reason": "Claude local history could not be read.", ...}
+
 return {
     "status": "unavailable",
     "reason": "Claude local history does not contain explicit quota snapshots.",
@@ -649,7 +695,7 @@ Run: `python3 -m pytest test_claude_usage.py -v`
 Expected: all tests PASS.
 
 Run: `bash src/claude-usage.5m.py`
-Expected: SwiftBar-formatted output that either shows local-history percentages or a local-history-specific fallback message, with no import/network/auth errors.
+Expected: SwiftBar-formatted output that either shows local-history percentages or a local-history-specific fallback message. The polyglot wrapper is preserved, but it should require only Python 3.10+ and standard-library imports.
 
 - [ ] **Step 5: Commit**
 

--- a/docs/superpowers/specs/2026-03-30-local-history-rate-limit-design.md
+++ b/docs/superpowers/specs/2026-03-30-local-history-rate-limit-design.md
@@ -4,7 +4,7 @@
 
 **Goal**
 
-This widget must compute Codex and Claude rate-limit percentages from local history artifacts only. It must stop reading `auth.json`, browser cookies, keychain entries, or any other credential source. If local history does not contain usable quota data, the widget may show cached values or a local-history error, but it must never fall back to credentials or network requests.
+This widget must compute Codex and Claude rate-limit percentages from local history artifacts only when trustworthy local quota snapshots exist. It must stop reading `auth.json`, browser cookies, keychain entries, or any other credential source. If local history does not contain usable quota data, the widget may show a cache that was itself derived from local history, or a local-history error, but it must never fall back to credentials or network requests.
 
 ## Context
 
@@ -20,7 +20,7 @@ Local file inspection in this environment showed:
 - Codex history exists in `~/.codex/sessions/**/*.jsonl`, `~/.codex/archived_sessions/*.jsonl`, and `~/.codex/session_index.jsonl`
 - Codex `event_msg` rows include `payload.type == "token_count"` plus `payload.rate_limits.primary/secondary`
 - Claude local history exists in `~/.claude/projects/**/*.jsonl`, `~/.claude/history.jsonl`, and `~/.claude/stats-cache.json`
-- Claude files are clearly local-only, but the exact stable quota snapshot shape for percentage-bearing rows still needs characterization during implementation
+- Claude files are clearly local-only, but the inspected files did not yet reveal a stable percentage-bearing quota snapshot
 
 ## Scope
 
@@ -100,7 +100,9 @@ Ordering:
 
 - Scan newest files first
 - Within a file, the newest valid token-count row wins
-- Stop once both primary and secondary windows have been found
+- The selected Codex snapshot must come from one `token_count.rate_limits` event
+- Do not merge primary from one event with secondary from another event
+- If the newest valid snapshot contains only one usable window, render only that window and mark the rest unavailable
 
 Expected output:
 
@@ -110,30 +112,31 @@ Expected output:
 
 ### Claude History Provider
 
-Claude support must remain local-only, but its artifact shape is less certain than Codex in the current workspace scan. The implementation should therefore be structured as a strict local parser with explicit discovery tests.
+Claude support must also remain local-only, but unlike Codex we do not yet have a confirmed percentage-bearing quota snapshot from the inspected files. To keep the design implementable without hidden private-session assumptions, Claude is split into two explicit phases.
 
-Primary candidate inputs:
+Phase 1 contract:
 
-- `~/.claude/projects/**/*.jsonl`
-- `~/.claude/history.jsonl`
+- Inputs are limited to `~/.claude/projects/**/*.jsonl` and `~/.claude/history.jsonl`
+- The parser only accepts explicit local rows that already contain both:
+  - a percentage value
+  - a reset timestamp or reset description that can be normalized
+- The parser may use regex extraction from saved assistant text if the `%` and reset details are present in the transcript itself
+- The parser must not derive percentages from token counts, message counts, or `~/.claude/stats-cache.json`
+- If no explicit percentage-bearing local row exists, Claude returns no items
 
-Optional candidate input:
+Phase 1 user-visible behavior:
 
-- `~/.claude/stats-cache.json`
+- Claude credential and network access is removed immediately
+- Claude shows a local-history-unavailable state until an explicit local quota snapshot is found
+- No guessed or synthesized `%` values are allowed
 
-Rules:
+Phase 2 gate:
 
-- Prefer explicit quota snapshots that contain percentage and reset-time information
-- If multiple local file shapes exist, encode them as ordered parsers from most explicit to least explicit
-- Do not infer percentages from token counts unless a stable mapping exists in the local artifact itself
-- If only textual limit messages exist, treat them as insufficient for `%` output and return no Claude items
+- Once one stable local Claude artifact shape is identified, add a redacted fixture to the repo
+- Promote that shape into a first-class parser with dedicated tests
+- Only after that fixture exists may Claude percentage display be considered fully supported
 
-Failure policy:
-
-- If Claude local history cannot yield a trustworthy percentage, return no Claude items rather than falling back to credentials
-- Surface a local-history-specific message so the limitation is visible and honest
-
-This keeps the contract with the user request: local artifacts only, no secret access, no invented percentages.
+This keeps the contract with the user request: local artifacts only, no secret access, no invented percentages, and no hidden dependency on manual local-history discovery during implementation.
 
 ## Configuration Changes
 
@@ -147,10 +150,15 @@ Replace or reinterpret configuration as:
 Recommended behavior:
 
 - `provider` selects which local-history parser to run
-- old `data_source` values are tolerated for backward compatibility but normalized internally to local history mode
+- old `data_source` values are accepted only as deprecated aliases
+- every legacy `data_source` value normalizes internally to the same local-history mode
 - README examples should move to the new `provider` terminology
 
-If keeping the old config keys is cheaper in the short term, the script should still document that all values now resolve to the same local-history backend.
+Exact migration rule:
+
+- no warning banner is required in the widget UI
+- README and config examples must mark `data_source` as deprecated
+- tests must verify that `"oauth"` and `"browser"` no longer change runtime behavior
 
 ## Error Handling
 
@@ -171,10 +179,22 @@ Replace with local-history outcomes:
 Fallback order:
 
 1. fresh local-history items
-2. cached items with stale reason
+2. local-history cache items with stale reason
 3. local-history-only error state
 
 The stale reason and empty-state copy should explicitly mention local history, not login state.
+
+Freshness rule:
+
+- a parsed local snapshot is fresh if at least one returned window has `resets_at` in the future
+- a parsed local snapshot becomes stale once all returned windows have reset timestamps in the past or missing reset metadata
+- projections and notifications run only for fresh local snapshots
+
+Cache migration rule:
+
+- cached payloads must be versioned with metadata such as `cache_schema_version` and `cache_source`
+- only caches stamped with `cache_source == "local_history"` are eligible after rollout
+- old caches created by browser, OAuth, or unknown sources must be ignored
 
 ## Testing Strategy
 
@@ -184,10 +204,14 @@ Required tests:
 
 - Codex parser extracts primary and secondary windows from `token_count.rate_limits`
 - Codex parser prefers the latest valid row
+- Codex parser keeps all rendered windows from the same snapshot event
+- Codex parser renders partial data when only one window exists in the newest valid snapshot
 - Codex parser falls back from `sessions` to `archived_sessions`
 - Codex parser ignores malformed JSONL lines
-- Claude parser tests use real redacted fixture rows from the user environment once a stable percentage-bearing shape is identified
+- Claude parser tests use committed redacted fixture rows only after a stable explicit percentage-bearing local transcript shape is identified
 - Claude parser returns no items when only insufficient local rows exist
+- Legacy cache entries without `cache_source == "local_history"` are ignored
+- Legacy `data_source` values do not change runtime behavior
 - main flow renders cache fallback when no fresh local data is available
 - no test imports or monkeypatches `requests`, browser cookies, or auth-file paths for the new happy path
 
@@ -212,7 +236,7 @@ Fixtures should be checked into the repo as redacted JSONL snippets rather than 
 
 Mitigations:
 
-- characterize the exact local file shapes with fixtures before deleting old code
+- characterize the exact local Claude file shape behind a committed fixture before claiming full Claude percentage support
 - fail closed for Claude percentages instead of guessing
 - preserve cache fallback and make the error copy explicit
 

--- a/docs/superpowers/specs/2026-03-30-local-history-rate-limit-design.md
+++ b/docs/superpowers/specs/2026-03-30-local-history-rate-limit-design.md
@@ -47,7 +47,27 @@ Keep the script as a single executable file for now, but split the data-loading 
 - `load_claude_history_items()`
 - shared file-scanning and JSONL parsing helpers
 
-Each provider returns a normalized list of items with this shape:
+Each provider returns a structured result, not just a raw item list:
+
+```python
+{
+    "status": "ok",  # ok | missing | unreadable | unavailable
+    "reason": "",
+    "snapshot_time": "2026-03-30T12:34:56+00:00",
+    "source_path": "/Users/.../file.jsonl",
+    "cacheable": True,
+    "items": [...],
+}
+```
+
+Status meanings:
+
+- `ok`: trustworthy local quota snapshot found
+- `missing`: no candidate local files found
+- `unreadable`: candidate files exist but could not be parsed or read
+- `unavailable`: local files were readable but did not contain trustworthy quota percentages
+
+When `status == "ok"`, `items` is a normalized list with this shape:
 
 ```python
 {
@@ -63,7 +83,7 @@ Each provider returns a normalized list of items with this shape:
 }
 ```
 
-The provider layer is responsible only for extracting facts from local files. Existing helpers remain responsible for:
+The provider layer is responsible only for extracting facts and result-state from local files. Existing helpers remain responsible for:
 
 - projected usage calculation
 - reset text formatting
@@ -95,11 +115,14 @@ Extraction rules:
 - Convert Unix `resets_at` to ISO8601 UTC strings
 - Map window minutes or seconds to `window_hours`
 - Ignore malformed or partial rows without aborting the scan
+- Use the parsed event timestamp from the same JSONL row as the global ordering key
+- If an event timestamp is missing or invalid, fall back to file modification time only as a last resort
 
 Ordering:
 
-- Scan newest files first
-- Within a file, the newest valid token-count row wins
+- Scan all candidate files
+- Extract candidate `token_count.rate_limits` snapshots plus their event timestamps
+- Choose the globally newest valid snapshot across all files
 - The selected Codex snapshot must come from one `token_count.rate_limits` event
 - Do not merge primary from one event with secondary from another event
 - If the newest valid snapshot contains only one usable window, render only that window and mark the rest unavailable
@@ -120,14 +143,14 @@ Phase 1 contract:
 - The parser only accepts explicit local rows that already contain both:
   - a percentage value
   - a reset timestamp or reset description that can be normalized
-- The parser may use regex extraction from saved assistant text if the `%` and reset details are present in the transcript itself
 - The parser must not derive percentages from token counts, message counts, or `~/.claude/stats-cache.json`
 - If no explicit percentage-bearing local row exists, Claude returns no items
+- Generic regex extraction from arbitrary assistant transcript text is not allowed in Phase 1
 
 Phase 1 user-visible behavior:
 
 - Claude credential and network access is removed immediately
-- Claude shows a local-history-unavailable state until an explicit local quota snapshot is found
+- Claude shows a deterministic local-history-unavailable state via provider result `status == "unavailable"` until an explicit local quota snapshot is found
 - No guessed or synthesized `%` values are allowed
 
 Phase 2 gate:
@@ -159,6 +182,14 @@ Exact migration rule:
 - no warning banner is required in the widget UI
 - README and config examples must mark `data_source` as deprecated
 - tests must verify that `"oauth"` and `"browser"` no longer change runtime behavior
+
+Config precedence matrix:
+
+- if `provider` is present and valid, use it
+- else if deprecated `data_source` is present, map `"oauth"` and `"browser"` to provider `"codex"` for backward compatibility with the current Codex-oriented widget
+- else default to provider `"codex"`
+- if both are present, `provider` wins
+- invalid `provider` values produce a local config error instead of silently falling back
 
 ## Error Handling
 
@@ -196,6 +227,12 @@ Cache migration rule:
 - only caches stamped with `cache_source == "local_history"` are eligible after rollout
 - old caches created by browser, OAuth, or unknown sources must be ignored
 
+Main-flow behavior:
+
+- `status == "ok"` and fresh snapshot: render items, update cache, evaluate notifications
+- `status == "ok"` and stale snapshot: render stale items without notifications and write a stale reason
+- `status in {"missing", "unreadable", "unavailable"}`: try local-history cache, else render the matching local-history-only error
+
 ## Testing Strategy
 
 Add characterization-style tests around provider parsing and keep rendering tests focused on normalized items.
@@ -208,11 +245,13 @@ Required tests:
 - Codex parser renders partial data when only one window exists in the newest valid snapshot
 - Codex parser falls back from `sessions` to `archived_sessions`
 - Codex parser ignores malformed JSONL lines
+- Codex parser uses row event timestamp as the global newest-snapshot selector
 - Claude parser tests use committed redacted fixture rows only after a stable explicit percentage-bearing local transcript shape is identified
 - Claude parser returns no items when only insufficient local rows exist
 - Legacy cache entries without `cache_source == "local_history"` are ignored
 - Legacy `data_source` values do not change runtime behavior
 - main flow renders cache fallback when no fresh local data is available
+- source-level tests assert that runtime code no longer references `auth.json`, cookie parsing, usage URLs, `requests`, or browser-cookie imports
 - no test imports or monkeypatches `requests`, browser cookies, or auth-file paths for the new happy path
 
 Fixtures should be checked into the repo as redacted JSONL snippets rather than building complex mocks.
@@ -243,6 +282,7 @@ Mitigations:
 ## Success Criteria
 
 - The script does not read `auth.json`, cookies, keychain entries, or call remote usage endpoints
+- The runtime code no longer contains credential or network fallback branches for usage fetching
 - Codex percentage display comes from local session history only
 - Claude percentage display also comes from local artifacts only when trustworthy local data exists
 - Missing local data results in cache or an honest local-history error, never a credential prompt

--- a/docs/superpowers/specs/2026-03-30-local-history-rate-limit-design.md
+++ b/docs/superpowers/specs/2026-03-30-local-history-rate-limit-design.md
@@ -1,0 +1,225 @@
+# Local History Rate Limit Design
+
+**Date:** 2026-03-30
+
+**Goal**
+
+This widget must compute Codex and Claude rate-limit percentages from local history artifacts only. It must stop reading `auth.json`, browser cookies, keychain entries, or any other credential source. If local history does not contain usable quota data, the widget may show cached values or a local-history error, but it must never fall back to credentials or network requests.
+
+## Context
+
+The current script has moved from the original Claude browser-based fetch path toward a Codex-oriented implementation, but it still depends on credentialed sources:
+
+- Codex OAuth via `~/.codex/auth.json` and `https://chatgpt.com/backend-api/wham/usage`
+- Browser-cookie parsing of `https://chatgpt.com/codex/settings/usage`
+
+The reference direction from `kentoku24/CodexBar` issue 1 and the surrounding CodexBar history is to prefer local session history, especially `token_count.rate_limits` stored in Codex JSONL session logs, before any status probe or dashboard path.
+
+Local file inspection in this environment showed:
+
+- Codex history exists in `~/.codex/sessions/**/*.jsonl`, `~/.codex/archived_sessions/*.jsonl`, and `~/.codex/session_index.jsonl`
+- Codex `event_msg` rows include `payload.type == "token_count"` plus `payload.rate_limits.primary/secondary`
+- Claude local history exists in `~/.claude/projects/**/*.jsonl`, `~/.claude/history.jsonl`, and `~/.claude/stats-cache.json`
+- Claude files are clearly local-only, but the exact stable quota snapshot shape for percentage-bearing rows still needs characterization during implementation
+
+## Scope
+
+In scope:
+
+- Replace all credentialed fetch paths with local-history readers
+- Introduce provider-style local readers for Codex and Claude
+- Normalize both providers into the existing `items` shape used by rendering
+- Preserve existing menubar/dropdown rendering, burn-rate projection, cache fallback, and notifications where inputs still exist
+- Update tests and README for local-history-only behavior
+
+Out of scope:
+
+- Adding any new online fetch path
+- Reaching into keychain, cookies, OAuth refresh, or browser sessions as a fallback
+- Reworking the overall UI beyond what is required to explain local-history-only failures
+
+## Proposed Architecture
+
+Keep the script as a single executable file for now, but split the data-loading logic into explicit provider helpers:
+
+- `load_usage_items(provider_name, config)`
+- `load_codex_history_items()`
+- `load_claude_history_items()`
+- shared file-scanning and JSONL parsing helpers
+
+Each provider returns a normalized list of items with this shape:
+
+```python
+{
+    "key": "primary_window",
+    "label_en": "5-hour limit",
+    "label_jp": "現在のセッション",
+    "window_hours": 5,
+    "pct": 18,
+    "resets_at_raw": "2026-03-30T12:34:56+00:00",
+    "projected": None,
+    "reset": "",
+    "exhaust_info": None,
+}
+```
+
+The provider layer is responsible only for extracting facts from local files. Existing helpers remain responsible for:
+
+- projected usage calculation
+- reset text formatting
+- bar rendering
+- alert thresholds
+- stale cache display
+
+## Provider Design
+
+### Codex History Provider
+
+Codex support is based on confirmed local data shape.
+
+Primary inputs:
+
+- `~/.codex/sessions/**/*.jsonl`
+- `~/.codex/archived_sessions/*.jsonl`
+
+Records to inspect:
+
+- JSONL rows where `type == "event_msg"`
+- `payload.type == "token_count"`
+- `payload.rate_limits` exists
+
+Extraction rules:
+
+- Prefer the newest valid `payload.rate_limits`
+- Support both `primary`/`secondary` and the already-known `primary_window`/`secondary_window` naming variants if encountered
+- Convert Unix `resets_at` to ISO8601 UTC strings
+- Map window minutes or seconds to `window_hours`
+- Ignore malformed or partial rows without aborting the scan
+
+Ordering:
+
+- Scan newest files first
+- Within a file, the newest valid token-count row wins
+- Stop once both primary and secondary windows have been found
+
+Expected output:
+
+- 5-hour session usage
+- weekly usage
+- optional credits or other windows are ignored unless the current renderer can display them safely
+
+### Claude History Provider
+
+Claude support must remain local-only, but its artifact shape is less certain than Codex in the current workspace scan. The implementation should therefore be structured as a strict local parser with explicit discovery tests.
+
+Primary candidate inputs:
+
+- `~/.claude/projects/**/*.jsonl`
+- `~/.claude/history.jsonl`
+
+Optional candidate input:
+
+- `~/.claude/stats-cache.json`
+
+Rules:
+
+- Prefer explicit quota snapshots that contain percentage and reset-time information
+- If multiple local file shapes exist, encode them as ordered parsers from most explicit to least explicit
+- Do not infer percentages from token counts unless a stable mapping exists in the local artifact itself
+- If only textual limit messages exist, treat them as insufficient for `%` output and return no Claude items
+
+Failure policy:
+
+- If Claude local history cannot yield a trustworthy percentage, return no Claude items rather than falling back to credentials
+- Surface a local-history-specific message so the limitation is visible and honest
+
+This keeps the contract with the user request: local artifacts only, no secret access, no invented percentages.
+
+## Configuration Changes
+
+Current config still exposes online-oriented `data_source` values such as `oauth` and `browser`. That is misleading once credential access is removed.
+
+Replace or reinterpret configuration as:
+
+- preferred: `provider`: `"codex"` or `"claude"`
+- optional compatibility: accept old `data_source` keys but ignore their online meaning
+
+Recommended behavior:
+
+- `provider` selects which local-history parser to run
+- old `data_source` values are tolerated for backward compatibility but normalized internally to local history mode
+- README examples should move to the new `provider` terminology
+
+If keeping the old config keys is cheaper in the short term, the script should still document that all values now resolve to the same local-history backend.
+
+## Error Handling
+
+Remove all credential and network-specific branches:
+
+- no `requests` exceptions
+- no HTTP 401/403 handling
+- no token refresh
+- no browser-cookie import errors in normal operation
+
+Replace with local-history outcomes:
+
+- local history parsed successfully
+- local history missing
+- local history unreadable
+- local history present but quota fields unavailable
+
+Fallback order:
+
+1. fresh local-history items
+2. cached items with stale reason
+3. local-history-only error state
+
+The stale reason and empty-state copy should explicitly mention local history, not login state.
+
+## Testing Strategy
+
+Add characterization-style tests around provider parsing and keep rendering tests focused on normalized items.
+
+Required tests:
+
+- Codex parser extracts primary and secondary windows from `token_count.rate_limits`
+- Codex parser prefers the latest valid row
+- Codex parser falls back from `sessions` to `archived_sessions`
+- Codex parser ignores malformed JSONL lines
+- Claude parser tests use real redacted fixture rows from the user environment once a stable percentage-bearing shape is identified
+- Claude parser returns no items when only insufficient local rows exist
+- main flow renders cache fallback when no fresh local data is available
+- no test imports or monkeypatches `requests`, browser cookies, or auth-file paths for the new happy path
+
+Fixtures should be checked into the repo as redacted JSONL snippets rather than building complex mocks.
+
+## Implementation Notes
+
+- Prefer filesystem and JSON parsing from the standard library
+- Remove `requests` and `browser_cookie3` imports after the migration is complete
+- Keep JSONL scanning streaming-friendly so large history files do not need full in-memory loading
+- Add small helpers for:
+  - expanding candidate roots
+  - sorting files by modified time
+  - reading files newest-first where practical
+  - parsing one JSON object per line safely
+
+## Risks
+
+- Claude local files may not contain reliable percentage snapshots in every environment
+- Older Codex session files may use slightly different field names
+- Local-history-only behavior may make “first run” empty states more common
+
+Mitigations:
+
+- characterize the exact local file shapes with fixtures before deleting old code
+- fail closed for Claude percentages instead of guessing
+- preserve cache fallback and make the error copy explicit
+
+## Success Criteria
+
+- The script does not read `auth.json`, cookies, keychain entries, or call remote usage endpoints
+- Codex percentage display comes from local session history only
+- Claude percentage display also comes from local artifacts only when trustworthy local data exists
+- Missing local data results in cache or an honest local-history error, never a credential prompt
+- The renderer continues to show percentages and projections for valid local data without behavioral regression

--- a/src/claude-usage.5m.py
+++ b/src/claude-usage.5m.py
@@ -14,16 +14,16 @@ for py in $("$SHELL" -lic 'which -a python3' 2>/dev/null); do
     "$py" -c 'import requests' 2>/dev/null || continue
     exec "$py" "$0"
 done
-echo "⚠️ Claude | color=gray"
+echo "⚠️ Codex | color=gray"
 echo "---"
 echo "pip3 install requests (Python 3.10+)"
 exit
 '''
 #
-# <xbar.title>Claude Usage</xbar.title>
+# <xbar.title>Codex Usage</xbar.title>
 # <xbar.version>v2.1</xbar.version>
 # <xbar.author>kmatsunami</xbar.author>
-# <xbar.desc>Claude.ai の使用量（セッション / 全モデル / Sonnet）をメニューバーに表示</xbar.desc>
+# <xbar.desc>Codex の使用量をメニューバーに表示</xbar.desc>
 # <xbar.dependencies>python3,browser-cookie3,requests</xbar.dependencies>
 #
 # <swiftbar.hideAbout>true</swiftbar.hideAbout>
@@ -37,20 +37,22 @@ exit
 #   このファイルを SwiftBar のプラグインフォルダにコピーして chmod +x
 #
 # カスタマイズ:
-#   ~/.claude-usage-config.json を作成して設定を上書き可能
-#   例: {"warn_pct": 70, "alert_pct": 90, "bar_width": 16,
-#        "metrics": ["five_hour", "seven_day"]}
+#   ~/.codex-usage-config.json を作成して設定を上書き可能
+#   例: {"warn_pct": 70, "alert_pct": 90, "bar_width": 16}
 
 import sys
 import json
+import re
+import os
+import html as html_lib
 import subprocess
-from datetime import datetime, timezone
+from datetime import datetime, timezone, timedelta
 from pathlib import Path
 
 try:
     import requests
 except ImportError:
-    print("⚠️ Claude Usage")
+    print("⚠️ Codex Usage")
     print("---")
     print("依存ライブラリ不足: requests")
     print("ターミナルで実行してください | size=11 color=gray")
@@ -64,37 +66,64 @@ try:
 except ImportError:
     HAS_BROWSER_COOKIE3 = False
 
-BASE_URL        = "https://claude.ai"
-OAUTH_API_URL   = "https://api.anthropic.com/api/oauth/usage"
-CONFIG_PATH     = Path.home() / ".claude-usage-config.json"
-ALERT_STATE_PATH = Path.home() / ".claude-usage-alerted.json"
-CACHE_PATH      = Path.home() / ".claude-usage-cache.json"
+PRODUCT_NAME = "Codex"
+USAGE_URL = "https://chatgpt.com/codex/settings/usage"
+CODEX_API_URL = "https://chatgpt.com/backend-api/wham/usage"
+CODEX_AUTH_ENDPOINT = "https://auth.openai.com/oauth/token"
+CODEX_CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann"
+CODEX_REFRESH_DAYS = 8
 
-# デフォルト設定（~/.claude-usage-config.json で上書き可能）
+CODEX_AUTH_PATHS = [
+    Path.home() / ".codex" / "auth.json",
+    Path.home() / ".config" / "codex" / "auth.json",
+]
+
+CONFIG_PATHS = [
+    Path.home() / ".codex-usage-config.json",
+    Path.home() / ".claude-usage-config.json",
+]
+ALERT_STATE_PATHS = [
+    Path.home() / ".codex-usage-alerted.json",
+    Path.home() / ".claude-usage-alerted.json",
+]
+CACHE_PATHS = [
+    Path.home() / ".codex-usage-cache.json",
+    Path.home() / ".claude-usage-cache.json",
+]
+
 DEFAULT_CONFIG = {
     "caution_pct": 60,  # 予測使用率の注意閾値（🟡）
     "warn_pct":    80,  # 予測使用率の警告閾値（🟠）
     "alert_pct":  100,  # 予測使用率のアラート閾値（🔴）
     "bar_width": 12,    # プログレスバーの幅（文字数）
-    "metrics": ["five_hour", "seven_day", "seven_day_sonnet"],  # 表示する指標
-    # データ取得方式: "browser"（browser_cookie3 + claude.ai API）
-    #               "oauth" （macOS Keychain の OAuth トークン + api.anthropic.com）
+    "metrics": [],      # 空なら取得できた全指標を表示
+    # データ取得方式: "oauth"（Codex auth.json + backend-api/wham/usage）
+    #               "browser"（OpenAI dashboard の HTML を解析）
     "data_source": "oauth",
 }
 
-# 全指標の定義  (key, label_en, label_jp, window_hours)
-ALL_METRICS = [
-    ("five_hour",        "Session", "現在のセッション",   5),
-    ("seven_day",        "All",     "すべてのモデル",    168),
-    ("seven_day_sonnet", "Sonnet",  "Sonnet のみ",      168),
-]
+def first_existing_path(paths):
+    for path in paths:
+        if path.exists():
+            return path
+    return paths[0]
+
+
+def read_json(path):
+    return json.loads(path.read_text())
+
+
+def write_json(path, value):
+    path.write_text(json.dumps(value, ensure_ascii=False, indent=2))
+
 
 # ── 設定ロード ───────────────────────────────────────────────
 def load_config():
     config = dict(DEFAULT_CONFIG)
-    if CONFIG_PATH.exists():
+    path = first_existing_path(CONFIG_PATHS)
+    if path.exists():
         try:
-            user = json.loads(CONFIG_PATH.read_text())
+            user = read_json(path)
             for k, v in user.items():
                 if k in DEFAULT_CONFIG:
                     config[k] = v
@@ -105,16 +134,17 @@ def load_config():
 # ── 通知アラート ─────────────────────────────────────────────
 def load_alert_state():
     """送信済みアラートの状態を読み込む。"""
-    if ALERT_STATE_PATH.exists():
+    path = first_existing_path(ALERT_STATE_PATHS)
+    if path.exists():
         try:
-            return json.loads(ALERT_STATE_PATH.read_text())
+            return read_json(path)
         except Exception:
             pass
     return {}
 
 def save_alert_state(state):
     try:
-        ALERT_STATE_PATH.write_text(json.dumps(state, indent=2))
+        write_json(ALERT_STATE_PATHS[0], state)
     except Exception:
         pass
 
@@ -122,15 +152,16 @@ def save_alert_state(state):
 def save_cache(items):
     """正常取得時の items をキャッシュに保存する。"""
     try:
-        CACHE_PATH.write_text(json.dumps(items, ensure_ascii=False, indent=2))
+        write_json(CACHE_PATHS[0], items)
     except Exception:
         pass
 
 def load_cache():
     """前回の items をキャッシュから読み込む。なければ None。"""
-    if CACHE_PATH.exists():
+    path = first_existing_path(CACHE_PATHS)
+    if path.exists():
         try:
-            return json.loads(CACHE_PATH.read_text())
+            return read_json(path)
         except Exception:
             pass
     return None
@@ -164,7 +195,7 @@ def check_and_notify(items, config):
 
         if proj >= config["alert_pct"] and state.get(alert_key) != resets_at:
             send_notification(
-                "Claude Usage 🔴",
+                f"{PRODUCT_NAME} Usage 🔴",
                 f"{label}の予測使用率が {proj:.0f}% に達します（上限超過）",
             )
             state[alert_key] = resets_at
@@ -172,7 +203,7 @@ def check_and_notify(items, config):
             changed = True
         elif proj >= config["warn_pct"] and state.get(warn_key) != resets_at:
             send_notification(
-                "Claude Usage 🟡",
+                f"{PRODUCT_NAME} Usage 🟡",
                 f"{label}の予測使用率が {proj:.0f}% に達します",
             )
             state[warn_key] = resets_at
@@ -181,79 +212,410 @@ def check_and_notify(items, config):
     if changed:
         save_alert_state(state)
 
-# ── browser モード: Cookie 取得 ────────────────────────────
-def get_session(cookie_jar):
+# ── Codex: 取得とパース ────────────────────────────────────
+def get_session(cookie_jar, referer=USAGE_URL):
     s = requests.Session()
     headers = {
         "User-Agent": (
             "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
             "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/145.0.0.0 Safari/537.36"
         ),
-        "Accept": "application/json",
+        "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
         "Content-Type": "application/json",
-        "Referer": "https://claude.ai/settings/usage",
+        "Referer": referer,
     }
     s.headers.update(headers)
     for c in cookie_jar:
         s.cookies.set(c.name, c.value, domain=c.domain)
     return s
 
-def get_org_uuid(session):
-    r = session.get(f"{BASE_URL}/api/organizations", timeout=10)
-    r.raise_for_status()
-    orgs = r.json()
-    if not orgs:
-        raise RuntimeError("組織が見つかりません")
-    return orgs[0]["uuid"]
-
-def get_usage(session, org_uuid):
-    r = session.get(f"{BASE_URL}/api/organizations/{org_uuid}/usage", timeout=10)
-    r.raise_for_status()
-    return r.json()
-
-def fetch_usage_browser():
-    """browser_cookie3 経由で chrome.ai API からクォータ情報を取得する。"""
+def _browser_cookie_jar():
     if not HAS_BROWSER_COOKIE3:
         raise RuntimeError(
             "browser_cookie3 がインストールされていません。"
-            "「pip3 install browser-cookie3」を実行するか、"
-            "data_source を \"oauth\" に変更してください。"
+            "「pip3 install browser-cookie3」を実行してください。"
         )
-    cookie_jar = browser_cookie3.chrome(domain_name=".claude.ai")
-    session = get_session(cookie_jar)
-    org_uuid = get_org_uuid(session)
-    return get_usage(session, org_uuid)
+    last_error = None
+    for domain in (".chatgpt.com", "chatgpt.com", ".openai.com"):
+        try:
+            return browser_cookie3.chrome(domain_name=domain)
+        except Exception as exc:
+            last_error = exc
+    raise RuntimeError(f"ChatGPT Cookie を取得できません: {last_error}")
 
-# ── oauth モード: macOS Keychain トークン ─────────────────
-def get_oauth_token():
-    """macOS Keychain から Claude Code OAuth アクセストークンを取得する。"""
-    result = subprocess.run(
-        ["security", "find-generic-password", "-s", "Claude Code-credentials", "-w"],
-        capture_output=True, text=True, timeout=5,
+def _find_json_scripts(html_text):
+    patterns = [
+        r'<script[^>]+id="__NEXT_DATA__"[^>]*>(.*?)</script>',
+        r'<script[^>]+type="application/json"[^>]*>(.*?)</script>',
+    ]
+    blobs = []
+    for pattern in patterns:
+        for match in re.finditer(pattern, html_text, flags=re.IGNORECASE | re.DOTALL):
+            text = html_lib.unescape(match.group(1)).strip()
+            if text and text not in blobs:
+                blobs.append(text)
+    return blobs
+
+def _walk_json(value):
+    if isinstance(value, dict):
+        yield value
+        for child in value.values():
+            yield from _walk_json(child)
+    elif isinstance(value, list):
+        for child in value:
+            yield from _walk_json(child)
+
+def _infer_window_hours(candidate):
+    for key in ("window_hours", "period_hours", "cycle_hours", "duration_hours", "interval_hours"):
+        raw = candidate.get(key)
+        if isinstance(raw, (int, float)) and raw > 0:
+            return int(raw) if float(raw).is_integer() else float(raw)
+    raw_seconds = candidate.get("limit_window_seconds")
+    if isinstance(raw_seconds, (int, float)) and raw_seconds > 0:
+        hours = raw_seconds / 3600
+        return int(hours) if float(hours).is_integer() else hours
+    text = " ".join(
+        str(candidate.get(key, ""))
+        for key in ("key", "name", "slug", "label", "title", "description")
+    ).lower()
+    if any(term in text for term in ("5h", "5-hour", "5 hour", "five hour", "session")):
+        return 5
+    if any(term in text for term in ("weekly", "7d", "7-day", "7 day", "week", "all")):
+        return 168
+    return 168
+
+def _normalize_usage_candidate(candidate, fallback_index):
+    raw_pct = candidate.get("utilization")
+    if raw_pct is None:
+        raw_pct = candidate.get("percentage")
+    if raw_pct is None:
+        raw_pct = candidate.get("usage")
+    if raw_pct is None:
+        return None
+
+    try:
+        pct = int(float(raw_pct))
+    except Exception:
+        return None
+
+    resets_at = (
+        candidate.get("resets_at")
+        or candidate.get("reset_at")
+        or candidate.get("resetsAt")
+        or candidate.get("resetAt")
     )
-    if result.returncode != 0:
+    key = (
+        candidate.get("key")
+        or candidate.get("id")
+        or candidate.get("slug")
+        or candidate.get("name")
+        or f"usage_{fallback_index}"
+    )
+    label = (
+        candidate.get("label")
+        or candidate.get("title")
+        or candidate.get("name")
+        or str(key)
+    )
+    window_hours = _infer_window_hours(candidate)
+    return {
+        "key": str(key),
+        "label_en": str(label),
+        "label_jp": str(label),
+        "window_hours": window_hours,
+        "pct": pct,
+        "projected": None,
+        "reset": "",
+        "resets_at_raw": resets_at,
+        "exhaust_info": None,
+    }
+
+def extract_usage_items_from_html(html_text):
+    """Codex usage ページの HTML から usage アイテムを抽出する。"""
+    items = []
+    seen = set()
+    for blob in _find_json_scripts(html_text):
+        try:
+            payload = json.loads(blob)
+        except Exception:
+            continue
+        for idx, candidate in enumerate(_walk_json(payload)):
+            if not isinstance(candidate, dict):
+                continue
+            if "utilization" not in candidate and "percentage" not in candidate and "usage" not in candidate:
+                continue
+            item = _normalize_usage_candidate(candidate, idx)
+            if not item:
+                continue
+            signature = (
+                item["key"],
+                item["pct"],
+                item["resets_at_raw"],
+                item["window_hours"],
+                item["label_jp"],
+            )
+            if signature in seen:
+                continue
+            seen.add(signature)
+            items.append(item)
+    items.sort(key=lambda item: (item["window_hours"], item["label_jp"]))
+    return items
+
+def fetch_usage_browser():
+    """ChatGPT の usage ページ HTML をブラウザ Cookie で取得する。"""
+    cookie_jar = _browser_cookie_jar()
+    session = get_session(cookie_jar)
+    r = session.get(USAGE_URL, timeout=10)
+    r.raise_for_status()
+    items = extract_usage_items_from_html(r.text)
+    if not items:
+        raise RuntimeError("usage ページからデータを抽出できませんでした")
+    return items
+
+def _parse_token_payload(raw_text):
+    raw_text = raw_text.strip()
+    if not raw_text:
+        return {}
+    try:
+        data = json.loads(raw_text)
+    except Exception:
+        return {"access_token": raw_text}
+    if isinstance(data, str):
+        return {"access_token": data}
+    if isinstance(data, dict):
+        return data
+    return {}
+
+def codex_auth_paths():
+    paths = []
+    codex_home = os.environ.get("CODEX_HOME")
+    if codex_home:
+        paths.append(Path(codex_home) / "auth.json")
+    paths.extend(CODEX_AUTH_PATHS)
+    return paths
+
+def find_codex_auth_file():
+    return first_existing_path(codex_auth_paths())
+
+def load_codex_auth():
+    path = find_codex_auth_file()
+    if not path.exists():
         raise RuntimeError(
-            "Keychain に Claude Code-credentials が見つかりません。"
-            "Claude Code にログインしているか確認してください。"
+            "Codex の auth.json が見つかりません。"
+            "Codex にログインして ~/.codex/auth.json を作成してください。"
         )
-    data = json.loads(result.stdout.strip())
-    token = data.get("claudeAiOauth", {}).get("accessToken", "")
-    if not token:
-        raise RuntimeError("OAuth アクセストークンが空です。Claude Code を再ログインしてください。")
-    return token
+    try:
+        return path, read_json(path)
+    except Exception as exc:
+        raise RuntimeError(f"Codex auth.json を読めません: {exc}") from exc
+
+def _nested_get(data, *keys):
+    cursor = data
+    for key in keys:
+        if not isinstance(cursor, dict) or key not in cursor:
+            return None
+        cursor = cursor[key]
+    return cursor
+
+def _extract_access_token(auth):
+    for path in [
+        ("tokens", "access_token"),
+        ("tokens", "accessToken"),
+        ("access_token",),
+        ("accessToken",),
+        ("access", "token"),
+    ]:
+        token = _nested_get(auth, *path)
+        if isinstance(token, str) and token.strip():
+            return token.strip()
+    return ""
+
+def _extract_refresh_token(auth):
+    for path in [
+        ("tokens", "refresh_token"),
+        ("tokens", "refreshToken"),
+        ("refresh_token",),
+        ("refreshToken",),
+    ]:
+        token = _nested_get(auth, *path)
+        if isinstance(token, str) and token.strip():
+            return token.strip()
+    return ""
+
+def _extract_last_refresh(auth):
+    value = auth.get("last_refresh") if isinstance(auth, dict) else None
+    return value if isinstance(value, str) else ""
+
+def codex_needs_refresh(auth):
+    last_refresh = _extract_last_refresh(auth)
+    if not last_refresh:
+        return True
+    try:
+        last_ts = datetime.fromisoformat(last_refresh.replace("Z", "+00:00"))
+        return (datetime.now(timezone.utc) - last_ts).days >= CODEX_REFRESH_DAYS
+    except Exception:
+        return True
+
+def refresh_codex_token(refresh_token):
+    clean_token = refresh_token.split("|", 1)[0].strip()
+    response = requests.post(
+        CODEX_AUTH_ENDPOINT,
+        headers={"Content-Type": "application/json"},
+        json={
+            "client_id": CODEX_CLIENT_ID,
+            "grant_type": "refresh_token",
+            "refresh_token": clean_token,
+            "scope": "openid profile email",
+        },
+        timeout=10,
+    )
+    response.raise_for_status()
+    payload = response.json()
+    if payload.get("error"):
+        raise RuntimeError(payload.get("error_description") or payload["error"])
+    return payload
+
+def persist_codex_auth(path, auth, token_payload):
+    updated = dict(auth)
+    tokens = dict(updated.get("tokens") or {})
+    if token_payload.get("access_token"):
+        tokens["access_token"] = token_payload["access_token"]
+    if token_payload.get("refresh_token"):
+        tokens["refresh_token"] = token_payload["refresh_token"]
+    if token_payload.get("id_token"):
+        tokens["id_token"] = token_payload["id_token"]
+    updated["tokens"] = tokens
+    updated["last_refresh"] = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    write_json(path, updated)
+
+def _window_label(window_key, candidate):
+    text = " ".join(
+        str(candidate.get(key, ""))
+        for key in ("name", "label", "title", "description", "window_name")
+    ).lower()
+    if window_key == "primary_window" or "5-hour" in text or "5 hour" in text or "5h" in text:
+        return "現在のセッション", "5-hour limit", 5
+    if window_key == "secondary_window" or "weekly" in text or "week" in text or "7d" in text:
+        return "すべてのモデル", "Weekly limit", 168
+    if "code review" in text or "review" in text:
+        return "Code review", "Code review limit", 168
+    return str(candidate.get("label") or candidate.get("title") or window_key), str(window_key), _infer_window_hours(candidate)
+
+def _pct_from_candidate(candidate):
+    for key in ("used_percent", "utilization", "percentage", "usage"):
+        raw = candidate.get(key)
+        if raw is None:
+            continue
+        try:
+            return int(round(float(raw)))
+        except Exception:
+            continue
+    remaining = candidate.get("remainingFraction") or candidate.get("remaining_fraction")
+    if remaining is None:
+        return None
+    try:
+        return int(round((1 - float(remaining)) * 100))
+    except Exception:
+        return None
+
+def _resets_from_candidate(candidate):
+    for key in ("resets_at", "reset_at", "resetAt", "reset_at_raw", "reset_time"):
+        value = candidate.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+        if isinstance(value, (int, float)) and value > 0:
+            return datetime.fromtimestamp(value, tz=timezone.utc).isoformat()
+    reset_after = candidate.get("reset_after_seconds")
+    if isinstance(reset_after, (int, float)) and reset_after > 0:
+        return (datetime.now(timezone.utc) + timedelta(seconds=reset_after)).isoformat()
+    return ""
+
+def _item_from_window(window_key, candidate):
+    pct = _pct_from_candidate(candidate)
+    if pct is None:
+        return None
+    label_jp, label_en, window_hours = _window_label(window_key, candidate)
+    return {
+        "key": window_key,
+        "label_en": label_en,
+        "label_jp": label_jp,
+        "window_hours": window_hours,
+        "pct": pct,
+        "projected": None,
+        "reset": "",
+        "resets_at_raw": _resets_from_candidate(candidate),
+        "exhaust_info": None,
+    }
+
+def extract_usage_items_from_codex_payload(payload):
+    """Codex API の JSON から usage アイテムを抽出する。"""
+    if not isinstance(payload, dict):
+        return []
+
+    items = []
+    seen = set()
+
+    rate_limit = payload.get("rate_limit") or payload.get("rateLimit")
+    if isinstance(rate_limit, dict):
+        for window_key in ("primary_window", "secondary_window", "code_review_window"):
+            candidate = rate_limit.get(window_key)
+            if isinstance(candidate, dict):
+                item = _item_from_window(window_key, candidate)
+                if item:
+                    sig = (item["key"], item["pct"], item["resets_at_raw"], item["window_hours"])
+                    if sig not in seen:
+                        seen.add(sig)
+                        items.append(item)
+
+    if not items:
+        for candidate in _walk_json(payload):
+            if not isinstance(candidate, dict):
+                continue
+            item = _item_from_window(
+                str(candidate.get("window_key") or candidate.get("key") or candidate.get("name") or "usage"),
+                candidate,
+            )
+            if item:
+                sig = (item["key"], item["pct"], item["resets_at_raw"], item["window_hours"])
+                if sig not in seen:
+                    seen.add(sig)
+                    items.append(item)
+
+    items.sort(key=lambda item: (item["window_hours"], item["label_jp"]))
+    return items
 
 def fetch_usage_oauth():
-    """macOS Keychain の OAuth トークンで api.anthropic.com からクォータ情報を取得する。"""
-    token = get_oauth_token()
-    headers = {
-        "Authorization": f"Bearer {token}",
-        "anthropic-beta": "oauth-2025-04-20",
-        "User-Agent": "claude-code/2.0.32",
-        "Accept": "application/json",
-    }
-    r = requests.get(OAUTH_API_URL, headers=headers, timeout=10)
-    r.raise_for_status()
-    return r.json()
+    """Codex auth.json の OAuth トークンで backend-api/wham/usage を取得する。"""
+    path, auth = load_codex_auth()
+    refresh_token = _extract_refresh_token(auth)
+    if refresh_token and codex_needs_refresh(auth):
+        try:
+            token_payload = refresh_codex_token(refresh_token)
+            persist_codex_auth(path, auth, token_payload)
+            auth = read_json(path)
+        except Exception:
+            pass
+
+    access_token = _extract_access_token(auth)
+    if not access_token:
+        raise RuntimeError(
+            "Codex auth.json に access_token がありません。"
+            "Codex で再ログインしてください。"
+        )
+
+    response = requests.get(
+        CODEX_API_URL,
+        headers={
+            "Authorization": f"Bearer {access_token}",
+            "Accept": "application/json",
+        },
+        timeout=10,
+    )
+    response.raise_for_status()
+    items = extract_usage_items_from_codex_payload(response.json())
+    if not items:
+        raise RuntimeError("Codex usage API からデータを抽出できませんでした")
+    return items
 
 # ── 表示ヘルパー ─────────────────────────────────────────────
 def pct_color(pct):
@@ -360,11 +722,7 @@ def format_reset(resets_at_str):
 def main():
     config = load_config()
 
-    # config["metrics"] の順序でフィルタリング
-    enabled_keys = config["metrics"]
-    metrics = [(k, le, lj, wh) for k, le, lj, wh in ALL_METRICS if k in enabled_keys]
-
-    data_source = config.get("data_source", "browser")
+    data_source = config.get("data_source", "oauth")
 
     try:
         if data_source == "oauth":
@@ -376,7 +734,7 @@ def main():
         if cached:
             render_output(cached, config, stale_reason="オフライン（前回の値を表示中）")
         else:
-            print("📵 Claude  |  color=gray")
+            print(f"📵 {PRODUCT_NAME}  |  color=gray")
             print("---")
             print("オフライン  |  color=gray")
         return
@@ -385,7 +743,7 @@ def main():
         if cached:
             render_output(cached, config, stale_reason="タイムアウト（前回の値を表示中）")
         else:
-            print("⏳ Claude  |  color=gray")
+            print(f"⏳ {PRODUCT_NAME}  |  color=gray")
             print("---")
             print("タイムアウト  |  color=gray")
             print("↺ 再試行  |  refresh=true")
@@ -404,16 +762,16 @@ def main():
             render_output(cached, config, stale_reason=reason)
         else:
             if status in (401, 403):
-                print("🔑 Claude  |  color=gray")
+                print(f"🔑 {PRODUCT_NAME}  |  color=gray")
                 print("---")
                 if data_source == "oauth":
                     print("トークン期限切れ  |  color=red")
-                    print("Claude Code を再ログインしてください  |  color=gray size=11")
+                    print("ChatGPT へ再ログインしてください  |  color=gray size=11")
                 else:
                     print("ログインが必要です  |  color=red")
-                    print("claude.ai を開く  |  href=https://claude.ai/settings/usage")
+                    print(f"{USAGE_URL} を開く  |  href={USAGE_URL}")
             else:
-                print("⚠️ Claude  |  color=gray")
+                print(f"⚠️ {PRODUCT_NAME}  |  color=gray")
                 print("---")
                 print(f"HTTPエラー: {status}  |  color=red")
         return
@@ -422,40 +780,42 @@ def main():
         if cached:
             render_output(cached, config, stale_reason=f"エラー（前回の値を表示中）")
         else:
-            print("⚠️ Claude Usage")
+            print(f"⚠️ {PRODUCT_NAME} Usage")
             print("---")
             print(f"エラー: {str(e)[:120]}")
             print("---")
-            print("設定ページを開く | href=https://claude.ai/settings/usage")
+            print(f"設定ページを開く | href={USAGE_URL}")
         return
 
-    # 有効な指標だけ抽出し、各自の burn rate 予測も計算
-    items = []
-    for key, label_en, label_jp, window_hours in metrics:
-        data = usage.get(key)
-        if data is None:
-            continue
-        pct = int(data.get("utilization", 0))
-        resets_at = data.get("resets_at")
-        proj = calc_projected(pct, resets_at, window_hours)
-        items.append({
-            "key":          key,
-            "label_en":     label_en,
-            "label_jp":     label_jp,
-            "window_hours": window_hours,
-            "pct":          pct,
-            "projected":    proj,
-            "reset":        format_reset(resets_at),
-            "resets_at_raw": resets_at,
-            "exhaust_info": calc_exhaust_info(pct, proj, resets_at, window_hours),
-        })
+    items = usage
+    enabled_keys = [str(key) for key in config.get("metrics", []) if key]
+    if enabled_keys:
+        filtered = [item for item in items if item.get("key") in enabled_keys]
+        if filtered:
+            items = filtered
 
     if not items:
-        print("⚠️ Claude Usage")
+        print(f"⚠️ {PRODUCT_NAME} Usage")
         print("---")
         print("データなし（ログインが必要かもしれません）")
-        print("設定ページを開く | href=https://claude.ai/settings/usage")
+        print(f"設定ページを開く | href={USAGE_URL}")
         return
+
+    # 各自の burn rate 予測を計算
+    normalized_items = []
+    for item in items:
+        pct = int(item.get("pct", 0))
+        resets_at = item.get("resets_at_raw")
+        window_hours = item.get("window_hours", 168)
+        proj = calc_projected(pct, resets_at, window_hours)
+        normalized = dict(item)
+        normalized.update({
+            "projected": proj,
+            "reset": format_reset(resets_at),
+            "exhaust_info": calc_exhaust_info(pct, proj, resets_at, window_hours),
+        })
+        normalized_items.append(normalized)
+    items = normalized_items
 
     # キャッシュに保存（次回エラー時のフォールバック用）
     save_cache(items)
@@ -471,19 +831,14 @@ def render_output(items, config, stale_reason=None):
     stale_reason が指定されていればキャッシュ表示であることを示す。
     """
     # ── メニューバー タイトル ──────────────────────────────────
-    # 5h はフル表示、7d 系は悪い方のアイコンのみ（詳細はドロップダウン）
     _icon_severity = {"🟢": 0, "🟡": 1, "🟠": 2, "🔴": 3}
     bar_parts = []
-    worst_7d_icon = None
+    worst_icon = None
     for i in items:
         icon = burn_icon(i["projected"], config)
-        if i["window_hours"] < 24:
-            bar_parts.append(f"{icon} {i['pct']}%")
-        else:
-            if worst_7d_icon is None or _icon_severity.get(icon, 0) > _icon_severity.get(worst_7d_icon, 0):
-                worst_7d_icon = icon
-    if worst_7d_icon is not None:
-        bar_parts.append(worst_7d_icon)
+        bar_parts.append(f"{icon} {i['pct']}%")
+        if worst_icon is None or _icon_severity.get(icon, 0) > _icon_severity.get(worst_icon, 0):
+            worst_icon = icon
     bar_title = " ".join(bar_parts)
     if stale_reason:
         bar_title = f"⚠️ {bar_title}"
@@ -493,16 +848,8 @@ def render_output(items, config, stale_reason=None):
     print("---")
     if stale_reason:
         print(f"⚠️ {stale_reason}  |  color=red size=11")
-        print("claude.ai を開く  |  href=https://claude.ai/settings/usage")
+        print(f"{PRODUCT_NAME} の usage を開く  |  href={USAGE_URL}")
         print("---")
-
-    # 5h セクション用: 7d全消化目標を算出
-    seven_day_mult = None
-    for i in items:
-        info = i.get("exhaust_info")
-        if info and info.get("multiplier") is not None:
-            seven_day_mult = info["multiplier"]
-            break  # metrics 定義順で最初の 7d を採用
 
     for item in items:
         proj = item["projected"]
@@ -511,22 +858,12 @@ def render_output(items, config, stale_reason=None):
         wh = item["window_hours"]
         window_label = f"{wh}h" if wh < 24 else f"{wh // 24}d"
 
-        # 5h セクションのみ: 7d全消化目標
-        # 表示条件: 5h予測 < 100%（利用不可リスクなし）かつ目標 < 予測（達成圏内）
-        target_5h = None
-        if wh < 24 and seven_day_mult is not None and proj is not None and proj < 100:
-            candidate = round(proj * seven_day_mult, 1)
-            if candidate < proj:
-                target_5h = candidate
-
         bar = progress_bar(item["pct"], proj, width=config["bar_width"])
 
         print(f"{icon} {item['label_jp']}  |  color={c}")
 
         # バーラベル
-        if target_5h is not None:
-            bar_label = f"{item['pct']}%→{proj:.0f}% 🎯{target_5h:.0f}%"
-        elif proj is not None:
+        if proj is not None:
             bar_label = f"{item['pct']}% → {proj:.0f}%"
         else:
             bar_label = f"{item['pct']}%"
@@ -544,7 +881,7 @@ def render_output(items, config, stale_reason=None):
             print(f"   🔄 {item['reset']}  |  size=11 color=gray")
         print("---")
 
-    print("↗ claude.ai/settings/usage  |  href=https://claude.ai/settings/usage")
+    print(f"↗ {USAGE_URL}  |  href={USAGE_URL}")
     print("↺ 今すぐ更新  |  refresh=true")
 
 

--- a/test_claude_usage.py
+++ b/test_claude_usage.py
@@ -1,40 +1,116 @@
 """
-最低限のテスト:
-1. スクリプト単体で数値が出る（Claude.ai と同じ計算）
-2. SwiftBar 用の出力フォーマットになっている（メニューバーに数値が出る）
+Codex usage widget の最小テスト:
+1. Codex API payload から usage アイテムを抽出できる
+2. Codex auth.json を読んで backend-api/wham/usage を呼べる
 """
-import subprocess, os, re, pytest
 
-SCRIPT = os.path.join(os.path.dirname(__file__), "src", "claude-usage.5m.py")
-LIMITED_ENV = {
-    "HOME": os.path.expanduser("~"),
-    "TMPDIR": os.environ.get("TMPDIR", "/tmp"),
-    "PATH": "/usr/bin:/bin",
-}
+import importlib.util
+import io
+import json
+from contextlib import redirect_stdout
+from pathlib import Path
 
-
-def run_script():
-    return subprocess.run(
-        ["bash", SCRIPT],
-        capture_output=True, text=True, timeout=15,
-    )
+SCRIPT = Path(__file__).resolve().parent / "src" / "claude-usage.5m.py"
 
 
-def test_python_detected():
-    """限定環境でも Python が見つかり、bash フォールバックにならない"""
-    result = run_script()
-    # bash polyglot フォールバック時のエラーメッセージが出ていないことを確認
-    assert "pip3 install requests" not in result.stdout
+def load_module():
+    spec = importlib.util.spec_from_file_location("codex_usage", SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
 
 
-def test_menubar_title_has_percentage():
-    """1行目（メニューバータイトル）に % が含まれる"""
-    result = run_script()
-    first_line = result.stdout.splitlines()[0]
-    assert "%" in first_line, f"got: {first_line!r}"
+def sample_payload():
+    return {
+        "rate_limit": {
+            "primary_window": {
+                "used_percent": 18,
+                "limit_window_seconds": 18000,
+                "reset_after_seconds": 9000,
+                "reset_at": 1774466160,
+            },
+            "secondary_window": {
+                "used_percent": 41,
+                "limit_window_seconds": 604800,
+                "reset_after_seconds": 255832,
+                "reset_at": 1774711988,
+            },
+        }
+    }
 
 
-def test_output_has_separator():
-    """SwiftBar の区切り線 '---' が含まれる"""
-    result = run_script()
-    assert "---" in result.stdout
+def test_extract_usage_items_from_codex_payload():
+    module = load_module()
+    items = module.extract_usage_items_from_codex_payload(sample_payload())
+    assert [item["key"] for item in items] == ["primary_window", "secondary_window"]
+    assert items[0]["pct"] == 18
+    assert items[1]["window_hours"] == 168
+    assert items[0]["resets_at_raw"].endswith("+00:00")
+
+
+def test_fetch_usage_oauth_uses_auth_json_and_api(tmp_path, monkeypatch):
+    module = load_module()
+    auth_path = tmp_path / "auth.json"
+    auth_path.write_text(json.dumps({
+        "tokens": {
+            "access_token": "access-123",
+            "refresh_token": "refresh-456",
+        },
+        "last_refresh": "2026-03-26T00:00:00Z",
+    }))
+
+    monkeypatch.setattr(module, "CODEX_AUTH_PATHS", [auth_path])
+    monkeypatch.setattr(module, "codex_needs_refresh", lambda auth: False)
+
+    captured = {}
+
+    class FakeResponse:
+        def __init__(self, payload):
+            self.payload = payload
+
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return self.payload
+
+    def fake_get(url, headers=None, timeout=None):
+        captured["url"] = url
+        captured["headers"] = headers
+        captured["timeout"] = timeout
+        return FakeResponse(sample_payload())
+
+    monkeypatch.setattr(module.requests, "get", fake_get)
+
+    items = module.fetch_usage_oauth()
+    assert captured["url"] == module.CODEX_API_URL
+    assert captured["headers"]["Authorization"] == "Bearer access-123"
+    assert [item["key"] for item in items] == ["primary_window", "secondary_window"]
+
+
+def test_main_renders_codex_usage_url(monkeypatch):
+    module = load_module()
+    items = module.extract_usage_items_from_codex_payload(sample_payload())
+
+    monkeypatch.setattr(module, "load_config", lambda: {
+        "caution_pct": 60,
+        "warn_pct": 80,
+        "alert_pct": 100,
+        "bar_width": 12,
+        "metrics": [],
+        "data_source": "oauth",
+    })
+    monkeypatch.setattr(module, "fetch_usage_oauth", lambda: items)
+    monkeypatch.setattr(module, "check_and_notify", lambda *args, **kwargs: None)
+    monkeypatch.setattr(module, "save_cache", lambda *args, **kwargs: None)
+
+    buffer = io.StringIO()
+    with redirect_stdout(buffer):
+        module.main()
+
+    output = buffer.getvalue()
+    first_line = output.splitlines()[0]
+    assert "%" in first_line
+    assert module.USAGE_URL in output
+    assert "→" in output


### PR DESCRIPTION
## Summary
- park the current Codex widget migration work on its own branch
- preserve the in-progress script, test, README, and plan changes for later follow-up
- add `.worktrees/` to `.gitignore` so isolated workspaces are safe to create

## Why draft
This PR is intentionally parked while the active work continues on a separate local-history-only implementation branch.

## Tracking
- Refs #22

## Notes
- This branch is not the implementation branch for the current task
- It exists so the current changes stay resumable and reviewable later
